### PR TITLE
refactor: standardize UI colors, text sizes, icons for consistency

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,19 @@
 
 All notable changes made by Claude Code are documented here.
 
+## [2026-03-10]
+
+### Refactored
+- **UI consistency audit & fix**: Khảo sát toàn bộ codebase và fix tất cả UI inconsistencies theo design guidelines.
+  - **Text sizes** (29 chỗ, 14 files): `text-[11px]`→`text-xs`, `text-[8px]`→`text-[9px]`, `text-[14px]`→`text-sm`
+  - **Hardcoded colors** (~20 chỗ, 12 files): `green-500`/`green-400`→`emerald-500`/`emerald-400` cho success states; `purple-300`→`purple-400`; `yellow-400`→`amber-400`; `blue-400`→`sky-400` cho info states
+  - **Emoji → Lucide icon** (2 chỗ): ★ → `<Star />` trong cascade-panel và chat-view
+  - **Flex overflow** (5 chỗ): Thêm `min-w-0` vào flex-1 + truncate elements (agent-response, processing-group, chat-area, chat-view, markdown-renderer)
+  - **Icon sizing** (1 chỗ): `h-10 w-10`→`h-8 w-8` trong auth-gate (chuẩn size grid)
+
+### Changed
+- **Design guidelines updated** (`docs/design-guidelines.md`): Bổ sung tech stack table, semantic status color palette (8 loại), chat message colors, bookmark colors, data visualization colors, git/diff/role color maps, z-index scale, accessibility section, banned text sizes rule, component sizing guideline.
+
 ## [2026-03-09]
 
 ### Added

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -409,8 +409,8 @@ export default function Home() {
               {showChat && <span className="text-xs text-muted-foreground font-mono hidden md:inline">{steps.length > 0 ? `${steps.length} steps` : ''}</span>}
               {lastUpdate && <span className="text-xs text-muted-foreground hidden md:inline">{lastUpdate}</span>}
               {/* Connected indicator pill — visible on all screen sizes */}
-              <div className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium ${connected ? 'bg-green-500/10 text-green-400 border border-green-500/20' : 'bg-red-500/10 text-red-400 border border-red-500/20'}`}>
-                <div className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-green-400 animate-pulse' : 'bg-red-400'}`} />
+              <div className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium ${connected ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' : 'bg-red-500/10 text-red-400 border border-red-500/20'}`}>
+                <div className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-emerald-400 animate-pulse' : 'bg-red-400'}`} />
                 <span>{connected ? 'Connected' : 'Detecting...'}</span>
               </div>
             </div>

--- a/frontend/components/agent-bridge-view.tsx
+++ b/frontend/components/agent-bridge-view.tsx
@@ -128,7 +128,7 @@ export function AgentBridgeView() {
             <div className="flex items-center justify-between px-3 py-2 border-b border-border/20 shrink-0">
                 <div className="flex items-center gap-2">
                     <Bot className="w-3.5 h-3.5 text-primary/60" />
-                    <span className="text-[11px] font-semibold text-foreground/70">Agent Bridge</span>
+                    <span className="text-xs font-semibold text-foreground/70">Agent Bridge</span>
                     <span className={cn(
                         'flex items-center gap-1 text-[9px] font-mono px-1.5 py-0.5 rounded-full border',
                         status.state === 'ACTIVE'
@@ -230,7 +230,7 @@ export function AgentBridgeView() {
                             <Bot className="w-5 h-5 text-muted-foreground/20" />
                         </div>
                         <div className="text-center">
-                            <p className="text-[11px] text-muted-foreground/40 font-medium">Bridge not started</p>
+                            <p className="text-xs text-muted-foreground/40 font-medium">Bridge not started</p>
                             <p className="text-[10px] text-muted-foreground/25 mt-0.5">
                                 Start the bridge to relay Antigravity ↔ Pi
                             </p>
@@ -251,7 +251,7 @@ export function AgentBridgeView() {
                                         {entry.message}
                                     </p>
                                 </div>
-                                <span className="text-[8px] text-muted-foreground/25 font-mono shrink-0 mt-0.5">{time}</span>
+                                <span className="text-[9px] text-muted-foreground/25 font-mono shrink-0 mt-0.5">{time}</span>
                             </div>
                         );
                     })

--- a/frontend/components/agent-logs-view.tsx
+++ b/frontend/components/agent-logs-view.tsx
@@ -214,7 +214,7 @@ const LogItem = memo(function LogItem({ event }: { event: LogEvent }) {
                         )}
                     </div>
                     {preview && (
-                        <p className="text-[11px] text-foreground/60 mt-0.5 break-words leading-relaxed line-clamp-2">
+                        <p className="text-xs text-foreground/60 mt-0.5 break-words leading-relaxed line-clamp-2">
                             {preview}
                         </p>
                     )}
@@ -226,7 +226,7 @@ const LogItem = memo(function LogItem({ event }: { event: LogEvent }) {
                     className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 p-1 rounded hover:bg-muted/30"
                     title="Copy payload"
                 >
-                    {copied ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground/40" />}
+                    {copied ? <Check className="w-3 h-3 text-emerald-400" /> : <Copy className="w-3 h-3 text-muted-foreground/40" />}
                 </button>
             </div>
 
@@ -375,7 +375,7 @@ export function AgentLogsView() {
             <div className="flex items-center justify-between px-3 py-2 border-b border-border/20 shrink-0">
                 <div className="flex items-center gap-2">
                     <Activity className="w-3.5 h-3.5 text-primary/60" />
-                    <span className="text-[11px] font-semibold text-foreground/70">Live Logs</span>
+                    <span className="text-xs font-semibold text-foreground/70">Live Logs</span>
                     {/* WS status */}
                     <span className={cn(
                         'flex items-center gap-1 text-[9px] font-mono px-1.5 py-0.5 rounded-full border',
@@ -456,7 +456,7 @@ export function AgentLogsView() {
                             <Activity className="w-5 h-5 text-muted-foreground/20" />
                         </div>
                         <div>
-                            <p className="text-[11px] text-muted-foreground/40 font-medium">Waiting for events…</p>
+                            <p className="text-xs text-muted-foreground/40 font-medium">Waiting for events…</p>
                             <p className="text-[10px] text-muted-foreground/25 mt-0.5">
                                 Events appear here when the agent runs
                             </p>

--- a/frontend/components/analytics-panel.tsx
+++ b/frontend/components/analytics-panel.tsx
@@ -8,7 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { BarChart2, User, Bot, Wrench, Settings, XCircle } from 'lucide-react';
 
 const barColors = [
-    'bg-blue-500', 'bg-purple-500', 'bg-orange-500', 'bg-green-500',
+    'bg-blue-500', 'bg-purple-500', 'bg-orange-500', 'bg-emerald-500',
     'bg-yellow-500', 'bg-cyan-500', 'bg-red-500', 'bg-pink-500',
     'bg-lime-500', 'bg-sky-500',
 ];

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -495,7 +495,7 @@ export function AppSidebar({
                             {(nameValidationError || createError) && newWsName.trim() && (
                                 <p className="text-xs text-destructive">{nameValidationError || createError}</p>
                             )}
-                            <p className="text-[11px] text-muted-foreground">
+                            <p className="text-xs text-muted-foreground">
                                 This will create a folder in your workspace root directory.
                             </p>
                         </div>

--- a/frontend/components/auth-gate.tsx
+++ b/frontend/components/auth-gate.tsx
@@ -55,7 +55,7 @@ export function AuthGate({ children }: AuthGateProps) {
         <div className="min-h-dvh bg-background flex items-center justify-center p-4">
             <Card className="w-full max-w-sm">
                 <CardHeader className="text-center pb-2">
-                    <div className="mb-3"><Lock className="h-10 w-10 text-muted-foreground mx-auto" /></div>
+                    <div className="mb-3"><Lock className="h-8 w-8 text-muted-foreground mx-auto" /></div>
                     <CardTitle className="text-xl">AntigravityChat</CardTitle>
                     <CardDescription>Enter your access key to continue</CardDescription>
                 </CardHeader>

--- a/frontend/components/cascade-panel.tsx
+++ b/frontend/components/cascade-panel.tsx
@@ -5,7 +5,7 @@ import { cascadeSend, cascadeSubmit, getWorkspaces, getModels } from '@/lib/casc
 import type { Workspace, CascadeModel } from '@/lib/cascade-api';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Image as ImageIcon } from 'lucide-react';
+import { Image as ImageIcon, Star } from 'lucide-react';
 
 interface CascadeMessage {
     id: string;
@@ -248,14 +248,14 @@ export function CascadePanel({ currentConvId, currentWorkspace, wsVersion, onCas
                                             ws.workspaceName === targetWorkspace && 'bg-accent/30'
                                         )}
                                     >
-                                        <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', ws.workspaceName === targetWorkspace ? 'bg-green-400' : 'bg-muted-foreground/30')} />
+                                        <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', ws.workspaceName === targetWorkspace ? 'bg-emerald-400' : 'bg-muted-foreground/30')} />
                                         <div className="flex-1 min-w-0">
                                             <div className="font-medium truncate">{ws.workspaceName}</div>
                                             <div className="text-[10px] text-muted-foreground/60 font-mono truncate">
                                                 PID:{ws.pid} · Port:{ws.port}
                                             </div>
                                         </div>
-                                        {ws.workspaceName === targetWorkspace && <span className="text-[9px] text-green-400 font-medium shrink-0">TARGET</span>}
+                                        {ws.workspaceName === targetWorkspace && <span className="text-[9px] text-emerald-400 font-medium shrink-0">TARGET</span>}
                                     </button>
                                 ))}
                             </div>
@@ -297,17 +297,17 @@ export function CascadePanel({ currentConvId, currentWorkspace, wsVersion, onCas
                                             m.modelId === selectedModelId && 'bg-accent/30'
                                         )}
                                     >
-                                        <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', m.modelId === selectedModelId ? 'bg-blue-400' : 'bg-muted-foreground/30')} />
+                                        <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', m.modelId === selectedModelId ? 'bg-sky-400' : 'bg-muted-foreground/30')} />
                                         <div className="flex-1 min-w-0">
                                             <div className="font-medium truncate flex items-center gap-1">
                                                 {m.label}
-                                                {m.isRecommended && <span className="text-[8px] text-amber-400 font-semibold">★</span>}
+                                                {m.isRecommended && <Star className="w-2.5 h-2.5 text-amber-400" />}
                                                 {m.supportsImages && <ImageIcon className="h-2.5 w-2.5 text-muted-foreground/50" />}
                                             </div>
                                             <div className="flex items-center gap-1.5 mt-0.5">
                                                 <div className="h-1 flex-1 rounded-full bg-muted overflow-hidden">
                                                     <div
-                                                        className={cn('h-full rounded-full transition-all', m.quota > 0.5 ? 'bg-green-400' : m.quota > 0.2 ? 'bg-amber-400' : 'bg-red-400')}
+                                                        className={cn('h-full rounded-full transition-all', m.quota > 0.5 ? 'bg-emerald-400' : m.quota > 0.2 ? 'bg-amber-400' : 'bg-red-400')}
                                                         style={{ width: `${Math.round(m.quota * 100)}%` }}
                                                     />
                                                 </div>

--- a/frontend/components/chat-area.tsx
+++ b/frontend/components/chat-area.tsx
@@ -93,7 +93,7 @@ function UserMessage({ step, index, searchQuery, onStepClick, isBookmarked }: {
                     <Badge variant="outline" className="text-[9px] font-mono cursor-pointer hover:bg-muted/80 transition-colors" onClick={() => onStepClick?.(index)}>#{index + 1}</Badge>
                 </div>
             </div>
-            <div className="text-[14px] leading-relaxed"><MarkdownRenderer content={content} /></div>
+            <div className="text-sm leading-relaxed"><MarkdownRenderer content={content} /></div>
         </div>
     );
 }
@@ -128,7 +128,7 @@ function AgentResponse({ step, index, searchQuery, onStepClick, isBookmarked }: 
                     <Badge variant="outline" className="text-[9px] font-mono cursor-pointer hover:bg-muted/80 transition-colors" onClick={() => onStepClick?.(index)}>#{index + 1}</Badge>
                 </div>
             </div>
-            <div className="text-[14px] leading-relaxed"><MarkdownRenderer content={content} /></div>
+            <div className="text-sm leading-relaxed"><MarkdownRenderer content={content} /></div>
         </div>
     );
 }
@@ -185,9 +185,9 @@ function ProcessingGroup({ steps: groupSteps, searchQuery, onStepClick, bookmark
                             >
                                 <span className="shrink-0 mt-0.5"><StepIcon name={config.icon} className="text-muted-foreground/70" /></span>
                                 <span className="font-medium text-foreground/60 shrink-0 min-w-16">{config.label}</span>
-                                <span className="truncate opacity-60 flex-1">{content.substring(0, 150)}</span>
+                                <span className="truncate opacity-60 flex-1 min-w-0">{content.substring(0, 150)}</span>
                                 {bookmarkedSteps?.has(originalIndex) && <span className="shrink-0"><Star className="h-2.5 w-2.5 fill-yellow-500 text-yellow-500" /></span>}
-                                <Badge variant="outline" className="text-[8px] font-mono shrink-0 opacity-50">#{originalIndex + 1}</Badge>
+                                <Badge variant="outline" className="text-[9px] font-mono shrink-0 opacity-50">#{originalIndex + 1}</Badge>
                             </div>
                         );
                     })}
@@ -268,7 +268,7 @@ export function ChatArea({ steps, searchQuery, activeFilters, onStepClick, bookm
                 <div className="sticky top-0 z-10 -mx-6 -mt-5 mb-4">
                     <div className="h-[2px] bg-border/30">
                         <div
-                            className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-green-500 transition-all duration-300"
+                            className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-emerald-500 transition-all duration-300"
                             style={{
                                 width: containerRef.current
                                     ? `${Math.min(100, (containerRef.current.scrollTop / (containerRef.current.scrollHeight - containerRef.current.clientHeight)) * 100)}%`

--- a/frontend/components/chat-view.tsx
+++ b/frontend/components/chat-view.tsx
@@ -21,7 +21,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Settings, Folder, Zap, BarChart2, RefreshCcw, SendHorizontal, Square, Paperclip, GitBranch, Plus, X, ChevronDown, Activity, Download, Bell, BellOff, Rocket, ArrowDown as ArrowDownIcon, Camera, Brain, Image as ImageIcon } from 'lucide-react';
+import { Settings, Folder, Zap, BarChart2, RefreshCcw, SendHorizontal, Square, Paperclip, GitBranch, Plus, X, ChevronDown, Activity, Download, Bell, BellOff, Rocket, ArrowDown as ArrowDownIcon, Camera, Brain, Image as ImageIcon, Star } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 
 // === Props ===
@@ -505,12 +505,12 @@ export function ChatView({ steps, currentConvId, currentWorkspace, wsVersion, st
                                             >
                                                 <div className="flex items-center gap-2 min-w-0">
                                                     <span className="truncate">{m.label}</span>
-                                                    {m.isRecommended && <Badge variant="secondary" className="text-[8px] h-3.5 px-1 shrink-0">★</Badge>}
+                                                    {m.isRecommended && <Badge variant="secondary" className="text-[9px] h-3.5 px-1 shrink-0"><Star className="w-2.5 h-2.5 text-amber-400" /></Badge>}
                                                 </div>
                                                 <div className="flex items-center gap-1.5 shrink-0">
                                                     {m.supportsImages && <span className="text-[9px]"><ImageIcon className="h-3 w-3" /></span>}
                                                     <div className="w-12 h-1.5 rounded-full bg-muted overflow-hidden">
-                                                        <div className="h-full rounded-full bg-green-500/70" style={{ width: `${Math.round(m.quota * 100)}%` }} />
+                                                        <div className="h-full rounded-full bg-emerald-500/70" style={{ width: `${Math.round(m.quota * 100)}%` }} />
                                                     </div>
                                                 </div>
                                             </DropdownMenuItem>
@@ -550,7 +550,7 @@ export function ChatView({ steps, currentConvId, currentWorkspace, wsVersion, st
                                     <DropdownMenuContent align="end" className="w-56 mb-1 bg-popover/95 backdrop-blur-sm shadow-xl rounded-lg border-border">
                                         <DropdownMenuLabel className="flex items-center gap-2 text-xs font-normal text-muted-foreground px-2 py-1.5">
                                             <Folder className="w-3.5 h-3.5" />
-                                            <span className="truncate flex-1">{selectedWsName}</span>
+                                            <span className="truncate flex-1 min-w-0">{selectedWsName}</span>
                                         </DropdownMenuLabel>
                                         <DropdownMenuSeparator className="bg-border" />
                                         <DropdownMenuItem

--- a/frontend/components/chat/agent-response.tsx
+++ b/frontend/components/chat/agent-response.tsx
@@ -46,10 +46,10 @@ function ArtifactPreview({ uri }: { uri: string }) {
                 <Button
                     variant="ghost"
                     onClick={loadFile}
-                    className="mt-2 w-full justify-start gap-2 px-3 py-2.5 h-auto text-xs font-medium text-purple-300 border border-purple-500/20 bg-purple-950/15 hover:bg-purple-500/10 hover:border-purple-500/30 hover:text-purple-300 rounded-lg"
+                    className="mt-2 w-full justify-start gap-2 px-3 py-2.5 h-auto text-xs font-medium text-purple-400 border border-purple-500/20 bg-purple-950/15 hover:bg-purple-500/10 hover:border-purple-500/30 hover:text-purple-400 rounded-lg"
                 >
                     <FileText className="h-4 w-4 shrink-0" />
-                    <span className="flex-1 text-left truncate">{fileName}</span>
+                    <span className="flex-1 min-w-0 text-left truncate">{fileName}</span>
                     <span className="text-[10px] text-muted-foreground/50">Click to view →</span>
                 </Button>
             </SheetTrigger>
@@ -69,7 +69,7 @@ function ArtifactPreview({ uri }: { uri: string }) {
                             <div className="text-muted-foreground animate-pulse">Loading file content...</div>
                         )}
                         {error && (
-                            <div className="text-yellow-400/80 text-xs">
+                            <div className="text-amber-400/80 text-xs">
                                 <AlertTriangle className="h-3 w-3 inline mr-1" /> Could not load file: {error}
                                 <br /><span className="text-muted-foreground/50 text-[10px] mt-1 block">Path: {uri}</span>
                             </div>

--- a/frontend/components/chat/code-change-viewer.tsx
+++ b/frontend/components/chat/code-change-viewer.tsx
@@ -93,7 +93,7 @@ const FileChangeCard = memo(function FileChangeCard({ info, isAccept }: { info: 
                 )}
             >
                 <ChevronRight className={cn('h-3 w-3 text-muted-foreground shrink-0 transition-transform', expanded && 'rotate-90')} />
-                <span>{isAccept !== false ? <Check className="h-3.5 w-3.5 text-green-500" /> : <X className="h-3.5 w-3.5 text-red-500" />}</span>
+                <span>{isAccept !== false ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : <X className="h-3.5 w-3.5 text-red-400" />}</span>
                 <span className="font-mono font-semibold text-foreground/80 truncate">{name}</span>
                 <span className="text-[10px] text-muted-foreground/50 font-mono truncate hidden sm:inline">{lang}</span>
                 <span className="flex-1" />
@@ -106,8 +106,8 @@ const FileChangeCard = memo(function FileChangeCard({ info, isAccept }: { info: 
                     <Tabs value={tab} onValueChange={(v) => handleTabSwitch(v as 'diff' | 'file')}>
                         <div className="flex items-center">
                             <TabsList className="h-8 rounded-none bg-muted/10 border-b border-border/20 w-auto">
-                                <TabsTrigger value="diff" className="text-[11px] h-full rounded-none">Diff</TabsTrigger>
-                                <TabsTrigger value="file" className="text-[11px] h-full rounded-none">Full File</TabsTrigger>
+                                <TabsTrigger value="diff" className="text-xs h-full rounded-none">Diff</TabsTrigger>
+                                <TabsTrigger value="file" className="text-xs h-full rounded-none">Full File</TabsTrigger>
                             </TabsList>
                             <span className="flex-1" />
                             <span className="text-[10px] text-muted-foreground/40 pr-3 font-mono truncate max-w-[200px]" title={filePath}>{filePath}</span>
@@ -136,7 +136,7 @@ function DiffView({ lines }: { lines: DiffLine[] }) {
 
     return (
         <div className="overflow-x-auto max-h-[400px] overflow-y-auto scrollbar-thin">
-            <table className="w-full text-[11px] font-mono leading-[1.6]">
+            <table className="w-full text-xs font-mono leading-[1.6]">
                 <tbody>
                     {lines.map((line, i) => {
                         const add = isAdded(line.type);
@@ -209,7 +209,7 @@ function FullFileView({ content, loading, error }: { content: string | null; loa
 
     return (
         <div className="overflow-x-auto max-h-[400px] overflow-y-auto scrollbar-thin">
-            <table className="w-full text-[11px] font-mono leading-[1.6]">
+            <table className="w-full text-xs font-mono leading-[1.6]">
                 <tbody>
                     {lines.map((line, i) => (
                         <tr key={i} className="hover:bg-muted/20">

--- a/frontend/components/chat/processing-group.tsx
+++ b/frontend/components/chat/processing-group.tsx
@@ -108,8 +108,8 @@ export const ProcessingGroup = memo(function ProcessingGroup({ steps: groupSteps
                                         <div key={originalIndex} className="flex items-start gap-2 py-1.5 px-3 text-xs text-muted-foreground hover:bg-white/[0.03] rounded-md transition-colors">
                                             <StepIcon name={config.icon} className="shrink-0 mt-0.5 text-muted-foreground/70" />
                                             <span className="font-medium text-foreground/60 shrink-0 min-w-16">{config.label}</span>
-                                            <span className="truncate opacity-60 flex-1">{String(content ?? '').substring(0, 150)}</span>
-                                            <Badge variant="outline" className="text-[8px] font-mono shrink-0 opacity-50">#{originalIndex + 1}</Badge>
+                                            <span className="truncate opacity-60 flex-1 min-w-0">{String(content ?? '').substring(0, 150)}</span>
+                                            <Badge variant="outline" className="text-[9px] font-mono shrink-0 opacity-50">#{originalIndex + 1}</Badge>
                                             <RawJsonViewer step={step} />
                                         </div>
                                     );

--- a/frontend/components/conversation-list.tsx
+++ b/frontend/components/conversation-list.tsx
@@ -89,7 +89,7 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
     const getStatusColor = (status: string) => {
         if (status?.includes('RUNNING')) return 'bg-purple-400';
         if (status?.includes('WAITING')) return 'bg-amber-400';
-        if (status?.includes('DONE') || status?.includes('COMPLETED')) return 'bg-green-400';
+        if (status?.includes('DONE') || status?.includes('COMPLETED')) return 'bg-emerald-400';
         return 'bg-muted-foreground/30';
     };
 
@@ -106,7 +106,7 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
                             <h2 className="text-base font-semibold text-foreground">
                                 {workspace?.workspaceName || 'Workspace'}
                             </h2>
-                            <p className="text-[11px] text-muted-foreground">
+                            <p className="text-xs text-muted-foreground">
                                 {conversations.length} conversation{conversations.length !== 1 ? 's' : ''}
                             </p>
                         </div>

--- a/frontend/components/markdown-renderer.tsx
+++ b/frontend/components/markdown-renderer.tsx
@@ -101,7 +101,7 @@ function FileViewerModal({ target, onClose }: { target: CciTarget; onClose: () =
                 {/* Header */}
                 <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/30 shrink-0">
                     <FileCode2 className="w-4 h-4 text-primary/60 shrink-0" />
-                    <span className="text-xs font-mono text-foreground/70 truncate flex-1" title={target.path}>
+                    <span className="text-xs font-mono text-foreground/70 truncate flex-1 min-w-0" title={target.path}>
                         {filename}
                         {target.startLine > 0 && (
                             <span className="text-muted-foreground/50 ml-2">

--- a/frontend/components/plugin-manager.tsx
+++ b/frontend/components/plugin-manager.tsx
@@ -109,7 +109,7 @@ export function PluginManager({ open, onClose }: { open: boolean; onClose: () =>
                                 <div
                                     key={p.id}
                                     className={`flex items-center gap-3 px-4 py-3 rounded-lg border transition-colors ${p.installed
-                                            ? 'bg-green-500/5 border-green-500/20'
+                                            ? 'bg-emerald-500/5 border-emerald-500/20'
                                             : 'bg-muted/10 border-border/40 hover:border-border/60'
                                         }`}
                                 >
@@ -122,7 +122,7 @@ export function PluginManager({ open, onClose }: { open: boolean; onClose: () =>
                                                 </span>
                                             )}
                                             {p.installed && (
-                                                <Badge variant="secondary" className="text-[8px] h-4 px-1.5 bg-green-500/10 text-green-400 border-green-500/20">
+                                                <Badge variant="secondary" className="text-[9px] h-4 px-1.5 bg-emerald-500/10 text-emerald-400 border-emerald-500/20">
                                                     Installed
                                                 </Badge>
                                             )}

--- a/frontend/components/profile/credit-card.tsx
+++ b/frontend/components/profile/credit-card.tsx
@@ -18,7 +18,7 @@ export function CreditCard({ label, icon, used, available, total, pct }: {
             <div className="h-2 bg-muted/30 rounded-full overflow-hidden mb-1.5">
                 <div className={cn(
                     "h-full rounded-full transition-all duration-500",
-                    pct > 50 ? "bg-green-500/80" :
+                    pct > 50 ? "bg-emerald-500/80" :
                         pct > 20 ? "bg-amber-500/80" : "bg-red-500/80"
                 )} style={{ width: `${pct}%` }} />
             </div>

--- a/frontend/components/profile/feature-badge.tsx
+++ b/frontend/components/profile/feature-badge.tsx
@@ -14,7 +14,7 @@ export function FeatureBadge({ label, enabled, value }: { label: string; enabled
         <div className={cn(
             "px-3 py-2 rounded-lg border flex items-center gap-1.5",
             enabled
-                ? "bg-green-500/5 border-green-500/20 text-green-500"
+                ? "bg-emerald-500/5 border-emerald-500/20 text-emerald-500"
                 : "bg-muted/10 border-border/30 text-muted-foreground/50"
         )}>
             <span className="text-[10px]">{enabled ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}</span>

--- a/frontend/components/settings-view.tsx
+++ b/frontend/components/settings-view.tsx
@@ -93,9 +93,9 @@ export function SettingsView() {
     );
 
     const getModelIcon = (label: string) => {
-        if (label.toLowerCase().includes('gemini')) return <Sparkles className="h-3.5 w-3.5 text-blue-400" />;
-        if (label.toLowerCase().includes('claude')) return <CircleDot className="h-3.5 w-3.5 text-purple-500" />;
-        if (label.toLowerCase().includes('gpt')) return <CircleDot className="h-3.5 w-3.5 text-green-500" />;
+        if (label.toLowerCase().includes('gemini')) return <Sparkles className="h-3.5 w-3.5 text-sky-400" />;
+        if (label.toLowerCase().includes('claude')) return <CircleDot className="h-3.5 w-3.5 text-purple-400" />;
+        if (label.toLowerCase().includes('gpt')) return <CircleDot className="h-3.5 w-3.5 text-emerald-400" />;
         return <Bot className="h-3.5 w-3.5" />;
     };
 
@@ -157,7 +157,7 @@ export function SettingsView() {
                                                         <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary ml-1">API Default</span>
                                                     )}
                                                     {m.supportsImages && (
-                                                        <span className="text-[9px] text-blue-400"><Camera className="h-3 w-3" /></span>
+                                                        <span className="text-[9px] text-sky-400"><Camera className="h-3 w-3" /></span>
                                                     )}
                                                 </span>
                                             </SelectItem>
@@ -177,7 +177,7 @@ export function SettingsView() {
                                                         <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary ml-1">API Default</span>
                                                     )}
                                                     {m.supportsImages && (
-                                                        <span className="text-[9px] text-blue-400"><Camera className="h-3 w-3" /></span>
+                                                        <span className="text-[9px] text-sky-400"><Camera className="h-3 w-3" /></span>
                                                     )}
                                                 </span>
                                             </SelectItem>
@@ -241,7 +241,7 @@ export function SettingsView() {
                         {saving ? 'Saving…' : 'Save Settings'}
                     </Button>
                     {saveMsg && (
-                        <span className={cn("text-xs font-medium flex items-center gap-1", saveMsg === 'saved' ? "text-green-500" : "text-destructive")}>
+                        <span className={cn("text-xs font-medium flex items-center gap-1", saveMsg === 'saved' ? "text-emerald-500" : "text-destructive")}>
                             {saveMsg === 'saved' ? <><Check className="h-3 w-3" /> Saved!</> : <><X className="h-3 w-3" /> Error saving</>}
                         </span>
                     )}

--- a/frontend/components/source-control-view.tsx
+++ b/frontend/components/source-control-view.tsx
@@ -116,7 +116,7 @@ function CopyButton({ text }: { text: string }) {
             className="flex items-center gap-1 px-2 py-1 rounded text-[10px] text-muted-foreground/50 hover:text-muted-foreground hover:bg-muted/40 transition-all"
             title="Copy"
         >
-            {copied ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
+            {copied ? <Check className="w-3 h-3 text-emerald-400" /> : <Copy className="w-3 h-3" />}
             <span>{copied ? 'Copied!' : 'Copy'}</span>
         </button>
     );
@@ -381,13 +381,13 @@ function ExplorerTab({ workspace }: { workspace: string }) {
                         </div>
                     )}
                     {!loading && error && (
-                        <div className="m-3 p-2.5 rounded-md bg-red-500/10 border border-red-500/20 text-[11px] text-red-400/80 flex items-start gap-2">
+                        <div className="m-3 p-2.5 rounded-md bg-red-500/10 border border-red-500/20 text-xs text-red-400/80 flex items-start gap-2">
                             <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
                             {error}
                         </div>
                     )}
                     {!loading && !error && rootEntries?.length === 0 && (
-                        <div className="px-4 py-8 text-center text-[11px] text-muted-foreground/30">
+                        <div className="px-4 py-8 text-center text-xs text-muted-foreground/30">
                             Folder is empty
                         </div>
                     )}
@@ -445,7 +445,7 @@ function ExplorerTab({ workspace }: { workspace: string }) {
                                     ))}
                                 </div>
                             ) : fileError ? (
-                                <div className="m-4 p-3 rounded-md bg-red-500/10 border border-red-500/20 text-[11px] text-red-400/80 flex items-start gap-2">
+                                <div className="m-4 p-3 rounded-md bg-red-500/10 border border-red-500/20 text-xs text-red-400/80 flex items-start gap-2">
                                     <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
                                     {fileError}
                                 </div>
@@ -617,7 +617,7 @@ function SourceControlTab({ workspace }: { workspace: string }) {
                         </div>
                     )}
                     {!loading && error && files.length === 0 && (
-                        <div className="m-3 p-2.5 rounded-md bg-amber-500/10 border border-amber-500/20 text-[11px] text-amber-400/80 flex items-start gap-2">
+                        <div className="m-3 p-2.5 rounded-md bg-amber-500/10 border border-amber-500/20 text-xs text-amber-400/80 flex items-start gap-2">
                             <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
                             {error}
                         </div>
@@ -625,7 +625,7 @@ function SourceControlTab({ workspace }: { workspace: string }) {
                     {!loading && !error && files.length === 0 && (
                         <div className="flex flex-col items-center gap-2 py-10 text-muted-foreground/20">
                             <GitBranch className="w-7 h-7" />
-                            <p className="text-[11px]">Working tree clean</p>
+                            <p className="text-xs">Working tree clean</p>
                         </div>
                     )}
                     {files.map(f => (
@@ -651,7 +651,7 @@ function SourceControlTab({ workspace }: { workspace: string }) {
                             </span>
 
                             <div className="flex flex-col min-w-0 flex-1">
-                                <span className="truncate font-mono text-[11px] text-foreground/80 leading-none mb-0.5">
+                                <span className="truncate font-mono text-xs text-foreground/80 leading-none mb-0.5">
                                     {basename(f.path)}
                                 </span>
                                 {dirname(f.path) && (
@@ -869,7 +869,7 @@ function CurrentFileView({ workspace, filePath }: { workspace: string; filePath:
 
     if (loading) return <SkeletonLines />;
     if (error) return (
-        <div className="m-4 p-3 rounded-md bg-red-500/10 border border-red-500/20 text-[11px] text-red-400/80 flex items-start gap-2">
+        <div className="m-4 p-3 rounded-md bg-red-500/10 border border-red-500/20 text-xs text-red-400/80 flex items-start gap-2">
             <AlertCircle className="w-3.5 h-3.5 mt-0.5 shrink-0" /> {error}
         </div>
     );

--- a/frontend/components/timeline.tsx
+++ b/frontend/components/timeline.tsx
@@ -15,7 +15,7 @@ const roleColors: Record<string, string> = {
     thinking: 'bg-gray-500',
     response: 'bg-purple-500',
     tool: 'bg-orange-500',
-    system: 'bg-green-500',
+    system: 'bg-emerald-500',
     error: 'bg-red-500',
 };
 
@@ -55,7 +55,7 @@ export function Timeline({ steps, onSelectStep }: TimelineProps) {
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-blue-500 inline-block" /> User</span>
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-purple-500 inline-block" /> Agent</span>
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-orange-500 inline-block" /> Tool</span>
-                    <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-green-500 inline-block" /> System</span>
+                    <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm bg-emerald-500 inline-block" /> System</span>
                 </div>
                 <span className="text-[9px] text-muted-foreground">#{steps.length}</span>
             </div>

--- a/frontend/components/user-profile.tsx
+++ b/frontend/components/user-profile.tsx
@@ -194,17 +194,17 @@ export function AccountInfoView() {
                                     <div className="flex items-center gap-2">
                                         <span className="text-xs font-medium">{model.label}</span>
                                         {model.modelId === defaultModel && (
-                                            <Badge variant="secondary" className="text-[8px] h-4 px-1.5">API Default</Badge>
+                                            <Badge variant="secondary" className="text-[9px] h-4 px-1.5">API Default</Badge>
                                         )}
                                         {model.isRecommended && (
-                                            <Badge variant="outline" className="text-[8px] h-4 px-1.5 border-amber-500/30 text-amber-500">Recommended</Badge>
+                                            <Badge variant="outline" className="text-[9px] h-4 px-1.5 border-amber-500/30 text-amber-500">Recommended</Badge>
                                         )}
                                     </div>
                                     <div className="text-[10px] text-muted-foreground/50 font-mono mt-0.5">{model.modelId}</div>
                                 </div>
                                 <div className="flex items-center gap-2 shrink-0">
                                     {model.supportsImages && (
-                                        <Badge variant="secondary" className="h-4 px-1.5 text-[8px] gap-0.5">
+                                        <Badge variant="secondary" className="h-4 px-1.5 text-[9px] gap-0.5">
                                             <ImageIcon className="h-2.5 w-2.5" />
                                         </Badge>
                                     )}


### PR DESCRIPTION
## Summary
- Standardize all non-standard text sizes (`text-[11px]`→`text-xs`, `text-[8px]`→`text-[9px]`, `text-[14px]`→`text-sm`) across 14 files
- Replace non-standard hardcoded colors with approved design palette (`green-*`→`emerald-*`, `purple-300`→`purple-400`, `yellow-400`→`amber-400`, `blue-400`→`sky-400`) across 12 files
- Replace ★ emoji with Lucide `<Star />` icon in cascade-panel and chat-view
- Add `min-w-0` to 5 flex-1+truncate elements to prevent text overflow
- Fix icon size `h-10 w-10`→`h-8 w-8` in auth-gate to match design size grid

## Files Changed (21 files)
- `frontend/app/page.tsx` — connected status colors
- `frontend/components/agent-bridge-view.tsx` — text sizes
- `frontend/components/agent-logs-view.tsx` — text sizes, green→emerald
- `frontend/components/analytics-panel.tsx` — chart bar color
- `frontend/components/app-sidebar.tsx` — text size
- `frontend/components/auth-gate.tsx` — icon size grid
- `frontend/components/cascade-panel.tsx` — ★→Star, green→emerald, blue→sky
- `frontend/components/chat-area.tsx` — text sizes, min-w-0, green→emerald
- `frontend/components/chat-view.tsx` — ★→Star, min-w-0, green→emerald
- `frontend/components/chat/agent-response.tsx` — purple-300→400, yellow→amber, min-w-0
- `frontend/components/chat/code-change-viewer.tsx` — text sizes, green/red→emerald/red-400
- `frontend/components/chat/processing-group.tsx` — text size, min-w-0
- `frontend/components/conversation-list.tsx` — text size, green→emerald
- `frontend/components/markdown-renderer.tsx` — min-w-0
- `frontend/components/plugin-manager.tsx` — text size, green→emerald
- `frontend/components/profile/credit-card.tsx` — green→emerald
- `frontend/components/profile/feature-badge.tsx` — green→emerald
- `frontend/components/settings-view.tsx` — blue→sky, purple→purple-400, green→emerald
- `frontend/components/source-control-view.tsx` — text sizes, green→emerald
- `frontend/components/timeline.tsx` — system role green→emerald
- `frontend/components/user-profile.tsx` — text sizes

## Test plan
- [x] Build passes (`npx next build` — compiled successfully, 0 errors)
- [x] Visual check: status indicators (connected/disconnected dots) use emerald/red
- [x] Visual check: text sizes consistent (no tiny/large outliers)
- [x] Visual check: Star icon renders correctly in model selector
- [x] Check truncated text in chat messages doesn't overflow on narrow screens