### PR TITLE
feat: display generated images in chat view

### DIFF
--- a/frontend/components/chat-view.tsx
+++ b/frontend/components/chat-view.tsx
@@ -49,6 +49,7 @@ import { groupSteps } from './chat/chat-helpers';
 import { UserMessage } from './chat/user-message';
 import { AgentResponse } from './chat/agent-response';
 import { ProcessingGroup } from './chat/processing-group';
+import { GeneratedImageStep } from './chat/generated-image-step';
 import { StreamingIndicator } from './chat/streaming-indicator';
 import { WorkflowAutocomplete } from './workflow-autocomplete';
 import type { WorkflowAutocompleteHandle } from './workflow-autocomplete';
@@ -446,6 +447,10 @@ export function ChatView({ steps, currentConvId, currentWorkspace, wsVersion, st
                                     if (group.type === 'response') {
                                         const { step, originalIndex } = group.steps[0];
                                         return <div key={`r-${gIdx}`} className={animClass}><AgentResponse step={step} index={originalIndex} /></div>;
+                                    }
+                                    if (group.type === 'image') {
+                                        const { step, originalIndex } = group.steps[0];
+                                        return <div key={`img-${gIdx}`} className={animClass}><GeneratedImageStep step={step} originalIndex={originalIndex} /></div>;
                                     }
                                     return <div key={`p-${gIdx}`} className={animClass}><ProcessingGroup steps={group.steps} cascadeId={activeCascadeId} totalStepCount={displaySteps.length} /></div>;
                                 })}

--- a/frontend/components/chat/chat-helpers.ts
+++ b/frontend/components/chat/chat-helpers.ts
@@ -16,9 +16,13 @@ export function isAgentResponse(step: Step): boolean {
     return false;
 }
 
+export function isGenerateImage(step: Step): boolean {
+    return step.type === 'CORTEX_STEP_TYPE_GENERATE_IMAGE' || !!step.generateImage;
+}
+
 // === Types ===
 export interface StepGroup {
-    type: 'user' | 'response' | 'processing';
+    type: 'user' | 'response' | 'processing' | 'image';
     steps: { step: Step; originalIndex: number }[];
 }
 
@@ -32,6 +36,7 @@ export function groupSteps(steps: Step[]): StepGroup[] {
     steps.forEach((step, idx) => {
         if (isUserInput(step)) { flush(); groups.push({ type: 'user', steps: [{ step, originalIndex: idx }] }); }
         else if (isAgentResponse(step)) { flush(); groups.push({ type: 'response', steps: [{ step, originalIndex: idx }] }); }
+        else if (isGenerateImage(step)) { flush(); groups.push({ type: 'image', steps: [{ step, originalIndex: idx }] }); }
         else { proc.push({ step, originalIndex: idx }); }
     });
     flush();

--- a/frontend/components/chat/generated-image-step.tsx
+++ b/frontend/components/chat/generated-image-step.tsx
@@ -1,0 +1,133 @@
+'use client';
+import { memo, useState } from 'react';
+import { Step } from '@/lib/types';
+import { Badge } from '@/components/ui/badge';
+import { ImagePlus, Download, Maximize2, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { API_BASE } from '@/lib/config';
+
+interface GeneratedImageStepProps {
+    step: Step;
+    originalIndex: number;
+}
+
+export const GeneratedImageStep = memo(function GeneratedImageStep({ step, originalIndex }: GeneratedImageStepProps) {
+    const [expanded, setExpanded] = useState(false);
+    const [imageError, setImageError] = useState(false);
+
+    const gi = step.generateImage || {};
+    const imageName = gi.imageName || 'Generated Image';
+    const prompt = gi.prompt || '';
+    const modelName = gi.modelName || '';
+    const uri = gi.generatedMedia?.uri || '';
+
+    // Build image URL via the secure /api/file/serve endpoint
+    const imageUrl = uri ? `${API_BASE}/api/file/serve?path=${encodeURIComponent(uri)}` : '';
+
+    const handleDownload = () => {
+        if (!imageUrl) return;
+        const a = document.createElement('a');
+        a.href = imageUrl;
+        a.download = `${imageName}.png`;
+        a.click();
+    };
+
+    return (
+        <>
+            <div className="mb-3 mx-4">
+                <div className="rounded-xl border border-border/50 bg-gradient-to-br from-purple-500/5 via-background to-pink-500/5 overflow-hidden">
+                    {/* Header */}
+                    <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/30">
+                        <ImagePlus className="h-4 w-4 text-purple-400" />
+                        <span className="text-sm font-medium text-foreground/90">{imageName}</span>
+                        <Badge variant="outline" className="text-[9px] font-mono text-muted-foreground/60 ml-auto">
+                            #{originalIndex + 1}
+                        </Badge>
+                        {modelName && (
+                            <Badge variant="secondary" className="text-[9px]">
+                                {modelName}
+                            </Badge>
+                        )}
+                    </div>
+
+                    {/* Image */}
+                    {imageUrl && !imageError ? (
+                        <div className="relative group">
+                            <img
+                                src={imageUrl}
+                                alt={prompt || imageName}
+                                className="w-full max-h-[500px] object-contain bg-black/20 cursor-pointer"
+                                onClick={() => setExpanded(true)}
+                                onError={() => setImageError(true)}
+                            />
+                            {/* Overlay actions */}
+                            <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                <Button
+                                    variant="secondary"
+                                    size="icon"
+                                    className="h-8 w-8 bg-background/80 backdrop-blur-sm shadow-lg"
+                                    onClick={() => setExpanded(true)}
+                                    title="Expand"
+                                >
+                                    <Maximize2 className="h-3.5 w-3.5" />
+                                </Button>
+                                <Button
+                                    variant="secondary"
+                                    size="icon"
+                                    className="h-8 w-8 bg-background/80 backdrop-blur-sm shadow-lg"
+                                    onClick={handleDownload}
+                                    title="Download"
+                                >
+                                    <Download className="h-3.5 w-3.5" />
+                                </Button>
+                            </div>
+                        </div>
+                    ) : imageError ? (
+                        <div className="flex items-center justify-center py-12 text-muted-foreground/60 text-sm">
+                            <ImagePlus className="h-8 w-8 mr-3 opacity-30" />
+                            Failed to load image
+                        </div>
+                    ) : (
+                        <div className="flex items-center justify-center py-12 text-muted-foreground/60 text-sm">
+                            <ImagePlus className="h-8 w-8 mr-3 opacity-30" />
+                            No image data available
+                        </div>
+                    )}
+
+                    {/* Prompt */}
+                    {prompt && (
+                        <div className="px-4 py-2.5 border-t border-border/30">
+                            <p className="text-xs text-muted-foreground/70 italic line-clamp-3">
+                                &ldquo;{prompt}&rdquo;
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Lightbox overlay */}
+            {expanded && imageUrl && (
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm cursor-pointer"
+                    onClick={() => setExpanded(false)}
+                >
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="absolute top-4 right-4 h-10 w-10 text-white/70 hover:text-white hover:bg-white/10"
+                        onClick={() => setExpanded(false)}
+                    >
+                        <X className="h-6 w-6" />
+                    </Button>
+                    <img
+                        src={imageUrl}
+                        alt={prompt || imageName}
+                        className="max-w-[90vw] max-h-[90vh] object-contain rounded-lg shadow-2xl"
+                        onClick={(e) => e.stopPropagation()}
+                    />
+                </div>
+            )}
+        </>
+    );
+});
+GeneratedImageStep.displayName = 'GeneratedImageStep';

--- a/frontend/components/ui/step-icon.tsx
+++ b/frontend/components/ui/step-icon.tsx
@@ -2,6 +2,7 @@ import {
     User, MessageCircle, Megaphone, FileEdit, CheckCircle, Zap, BarChart2,
     Keyboard, FileText, FolderOpen, Globe, ClipboardList, Search, XCircle,
     Save, MessageSquare, ScrollText, BookOpen, FileSearch, Settings, Wrench,
+    ImagePlus,
     type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -29,6 +30,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
     FileSearch,
     Settings,
     Wrench,
+    ImagePlus,
 };
 
 interface StepIconProps {

--- a/frontend/lib/step-utils.ts
+++ b/frontend/lib/step-utils.ts
@@ -23,6 +23,7 @@ export const STEP_DISPLAY: Record<string, StepDisplayConfig> = {
     'CORTEX_STEP_TYPE_KNOWLEDGE_ARTIFACTS': { role: 'system', icon: 'BookOpen', label: 'Knowledge', show: true },
     'CORTEX_STEP_TYPE_READ_URL_CONTENT': { role: 'tool', icon: 'Globe', label: 'Read URL', show: true },
     'CORTEX_STEP_TYPE_VIEW_CONTENT_CHUNK': { role: 'tool', icon: 'FileSearch', label: 'View Chunk', show: true },
+    'CORTEX_STEP_TYPE_GENERATE_IMAGE': { role: 'tool', icon: 'ImagePlus', label: 'Generate Image', show: true },
 };
 
 export function getStepConfig(type: string): StepDisplayConfig {
@@ -179,6 +180,13 @@ export function extractStepContent(step: Step): string | null {
     if (type === 'CORTEX_STEP_TYPE_KNOWLEDGE_ARTIFACTS') return '📚 Knowledge artifacts loaded';
     if (step.grepSearch || type === 'CORTEX_STEP_TYPE_GREP_SEARCH') { try { const args = JSON.parse(step.metadata?.argumentsJson || '{}'); return `🔍 \`${args.Query || ''}\` in \`${args.SearchPath || ''}\``; } catch { /* */ } return null; }
     if (step.find || type === 'CORTEX_STEP_TYPE_FIND') { try { const args = JSON.parse(step.metadata?.argumentsJson || '{}'); return `🔍 \`${args.Pattern || args.Query || ''}\` in \`${args.SearchDirectory || ''}\``; } catch { /* */ } return null; }
+
+    if (step.generateImage || type === 'CORTEX_STEP_TYPE_GENERATE_IMAGE') {
+        const gi = step.generateImage || {};
+        const name = gi.imageName || 'image';
+        const prompt = gi.prompt || '';
+        return `🖼️ **${name}**${prompt ? `\n_${prompt}_` : ''}`;
+    }
 
     if (step.metadata?.argumentsJson) {
         try {

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -98,6 +98,16 @@ export interface Step {
         totalTokens?: number;
     };
     conversationHistory?: unknown;
+    generateImage?: {
+        prompt?: string;
+        imageName?: string;
+        modelName?: string;
+        generatedMedia?: {
+            mimeType?: string;
+            inlineData?: string;
+            uri?: string;
+        };
+    };
     grepSearch?: unknown;
     find?: unknown;
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -1052,8 +1052,9 @@ function setupRoutes(app) {
             }
 
             // Security: Only allow reading files within workspace directories
-            // Build allowed roots: defaultWorkspaceRoot (from settings) + all active workspace folders
+            // Build allowed roots: defaultWorkspaceRoot (from settings) + all active workspace folders + .gemini brain
             const { lsInstances, getSettings } = require('./config');
+            const os = require('os');
             const settings = getSettings();
             const allowedRoots = [];
 
@@ -1075,6 +1076,12 @@ function setupRoutes(app) {
                     }
                 }
             }
+
+            // 3. .gemini brain directory (generated images, artifacts, conversation data)
+            const geminiBrainDir = path.join(os.homedir(), '.gemini', 'antigravity', 'brain');
+            try {
+                allowedRoots.push(fs.realpathSync(geminiBrainDir));
+            } catch { /* skip if doesn't exist */ }
 
             // Deny if no workspace roots configured — nothing to allow
             if (allowedRoots.length === 0) {
@@ -1099,6 +1106,94 @@ function setupRoutes(app) {
             res.json({ content, path: filePath });
         } catch (e) {
             res.status(500).json({ error: 'Failed to read file' });
+        }
+    });
+
+    // === File serve — binary file serving for images/media ===
+    // Security: same workspace allowlist as POST /api/file/read + MIME type whitelist
+    app.get('/api/file/serve', (req, res) => {
+        try {
+            const fs = require('fs');
+            const path = require('path');
+            const os = require('os');
+
+            let filePath = typeof req.query.path === 'string' ? req.query.path : '';
+            // Handle file:// URIs
+            if (filePath.startsWith('file:///')) {
+                try { filePath = decodeURIComponent(new URL(filePath).pathname); } catch { filePath = decodeURIComponent(filePath.replace('file://', '')); }
+                if (/^\/[a-zA-Z]:/.test(filePath)) filePath = filePath.substring(1);
+            }
+            if (!filePath) return res.status(400).json({ error: 'Missing path parameter' });
+
+            // MIME whitelist — only serve image types
+            const ALLOWED_MIME = {
+                '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+                '.gif': 'image/gif', '.webp': 'image/webp',
+                '.bmp': 'image/bmp', '.ico': 'image/x-icon',
+            };
+            const ext = path.extname(filePath).toLowerCase();
+            if (!ALLOWED_MIME[ext]) {
+                return res.status(403).json({ error: 'File type not allowed' });
+            }
+
+            // Resolve real path (follows symlinks)
+            let realPath;
+            try {
+                realPath = fs.realpathSync(filePath);
+            } catch (e) {
+                if (e.code === 'ENOENT') return res.status(404).json({ error: 'File not found' });
+                return res.status(400).json({ error: 'Invalid file path' });
+            }
+
+            // Build allowed roots (same as POST /api/file/read)
+            const { lsInstances, getSettings } = require('./config');
+            const settings = getSettings();
+            const allowedRoots = [];
+            if (settings.defaultWorkspaceRoot) {
+                try { allowedRoots.push(fs.realpathSync(settings.defaultWorkspaceRoot)); } catch { }
+            }
+            for (const inst of lsInstances) {
+                if (inst.workspaceFolderUri) {
+                    const fsPath = uriToFsPath(inst.workspaceFolderUri);
+                    if (fsPath) { try { allowedRoots.push(fs.realpathSync(fsPath)); } catch { } }
+                }
+            }
+            const geminiBrainDir = path.join(os.homedir(), '.gemini', 'antigravity', 'brain');
+            try { allowedRoots.push(fs.realpathSync(geminiBrainDir)); } catch { }
+
+            if (allowedRoots.length === 0) {
+                return res.status(403).json({ error: 'Access denied: no workspace configured' });
+            }
+
+            // Verify file is within allowed roots
+            const isAllowed = allowedRoots.some(root => {
+                const normalizedRoot = path.resolve(root);
+                return process.platform === 'win32'
+                    ? realPath.toLowerCase().startsWith(normalizedRoot.toLowerCase() + path.sep) ||
+                    realPath.toLowerCase() === normalizedRoot.toLowerCase()
+                    : realPath.startsWith(normalizedRoot + path.sep) ||
+                    realPath === normalizedRoot;
+            });
+
+            if (!isAllowed) {
+                return res.status(403).json({ error: 'Access denied: file outside workspace' });
+            }
+
+            // Check file size (max 50MB)
+            const stat = fs.statSync(realPath);
+            if (stat.size > 50 * 1024 * 1024) {
+                return res.status(413).json({ error: 'File too large' });
+            }
+
+            // Serve with proper headers
+            res.setHeader('Content-Type', ALLOWED_MIME[ext]);
+            res.setHeader('Content-Length', stat.size);
+            res.setHeader('X-Content-Type-Options', 'nosniff');
+            res.setHeader('Content-Disposition', 'inline');
+            res.setHeader('Cache-Control', 'public, max-age=3600');
+            fs.createReadStream(realPath).pipe(res);
+        } catch (e) {
+            res.status(500).json({ error: 'Failed to serve file' });
         }
     });
 


### PR DESCRIPTION
# feat: Display Generated Images in Chat View

## Summary

Adds full support for rendering `CORTEX_STEP_TYPE_GENERATE_IMAGE` steps in the Chat Mirror frontend. Generated images (e.g. from `generate_image` tool calls) now display as rich, interactive cards directly in the conversation — not buried inside collapsed processing groups.

## Changes

### Backend — [src/routes.js](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/src/routes.js)

**New endpoint: `GET /api/file/serve`**
Serves binary image files with proper `Content-Type` headers. Secured with:
- ✅ Workspace allowlist (same as `POST /api/file/read`)
- ✅ `.gemini/antigravity/brain` directory allowlisted for generated images
- ✅ MIME whitelist — only `png, jpg, jpeg, gif, webp, bmp, ico` (no SVG — XSS risk)
- ✅ `fs.realpathSync()` — symlink bypass defense
- ✅ `+ path.sep` boundary check — prefix attack defense
- ✅ Windows case-insensitive comparison
- ✅ `typeof === 'string'` on query param — array injection defense  
- ✅ 50MB file size limit
- ✅ `X-Content-Type-Options: nosniff` + `Cache-Control: public, max-age=3600`

**Updated: `POST /api/file/read`**
- Added `.gemini/antigravity/brain` to `allowedRoots` (for artifact/image file reads)

### Frontend

| File | Change |
|------|--------|
| [lib/types.ts](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/lib/types.ts) | Added `generateImage` field to [Step](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/lib/types.ts#18-114) interface |
| [lib/step-utils.ts](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/lib/step-utils.ts) | Added `GENERATE_IMAGE` to `STEP_DISPLAY` config + [extractStepContent](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/lib/step-utils.ts#32-195) handler |
| [components/ui/step-icon.tsx](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/components/ui/step-icon.tsx) | Added `ImagePlus` icon to icon map |
| [components/chat/chat-helpers.ts](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/components/chat/chat-helpers.ts) | Added [isGenerateImage()](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/components/chat/chat-helpers.ts#19-22) + `'image'` group type (renders as top-level card, not collapsed) |
| [components/chat/generated-image-step.tsx](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/components/chat/generated-image-step.tsx) | **[NEW]** Image card component with gradient design, hover expand/download actions, fullscreen lightbox modal, prompt display, error states |
| [components/chat-view.tsx](file:///c:/Users/zacka/OneDrive/Desktop/Projects/Antigravity-Deck/frontend/components/chat-view.tsx) | Added render case for `'image'` groups |

## Security Audit

| Attack Vector | Defense | Status |
|---|---|---|
| Path traversal (`../../etc/passwd`) | `realpathSync` → allowlist | ✅ |
| Symlink bypass | `realpathSync` resolves before check | ✅ |
| Prefix attack (`/App` vs `/App-Evil`) | `+ path.sep` boundary | ✅ |
| Windows case (`C:\SECRET` vs `c:\secret`) | `.toLowerCase()` | ✅ |
| Arbitrary file types ([.js](file:///C:/tmp/routes-vinh.js), `.env`) | MIME whitelist | ✅ |
| SVG XSS | SVG excluded from whitelist | ✅ |
| Query param array injection | `typeof === 'string'` | ✅ |
| DoS via large file | 50MB limit | ✅ |
| Error message leaking | Generic error responses | ✅ |
