### PR TITLE
feat: add workspace resource monitor with real-time CPU/RAM tracking

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -25,6 +25,7 @@ import { AuthGate } from '@/components/auth-gate';
 import { AgentLogsView } from '@/components/agent-logs-view';
 import { AgentBridgeView } from '@/components/agent-bridge-view';
 import { SourceControlView } from '@/components/source-control-view';
+import { ResourceMonitorView } from '@/components/resource-monitor-view';
 
 // Lazy-load components that are hidden by default
 const AnalyticsPanel = dynamic(() => import('@/components/analytics-panel').then(m => ({ default: m.AnalyticsPanel })), { ssr: false });
@@ -41,7 +42,7 @@ function getStoredValue<T>(key: string, fallback: T): T {
 }
 
 export default function Home() {
-  const { connected, steps, conversations, currentConvId, cascadeStatus, conversationsVersion, stepContentVersion, selectConversation, lastUpdate } = useWebSocket();
+  const { connected, steps, conversations, currentConvId, cascadeStatus, conversationsVersion, stepContentVersion, workspaceResources, selectConversation, lastUpdate } = useWebSocket();
 
   const [showAnalytics, setShowAnalytics] = useState(() => getStoredValue('antigravity-show-analytics', false));
   const [showTimeline, setShowTimeline] = useState(() => {
@@ -94,6 +95,7 @@ export default function Home() {
   const [showBridge, setShowBridge] = useState(() => getStoredValue('antigravity-show-bridge', false));
   // NEW: When true, show Source Control / IDE view in main panel
   const [showSourceControl, setShowSourceControl] = useState(false);
+  const [showResources, setShowResources] = useState(false);
   // Bumped when sidebar creates a workspace, so panels refresh their lists
   const [wsVersion, setWsVersion] = useState(0);
 
@@ -120,7 +122,7 @@ export default function Home() {
     if (storedConvId) {
       selectConversation(storedConvId);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // run once on mount
 
   // Step detail state
@@ -139,6 +141,7 @@ export default function Home() {
     setShowLogs(false);
     setShowBridge(false);
     setShowSourceControl(false);
+    setShowResources(false);
   }, []);
 
   // === Sidebar: click workspace → show conversation list ===
@@ -218,6 +221,14 @@ export default function Home() {
     setShowSourceControl(true);
   }, [selectConversation, resetPanels]);
 
+  // === Show Resources ===
+  const handleShowResources = useCallback(() => {
+    selectConversation(null);
+    resetPanels();
+    setActiveWorkspace(null);
+    setShowResources(true);
+  }, [selectConversation, resetPanels]);
+
   // === Go Home — reset all navigation state to welcome screen ===
   const handleGoHome = useCallback(() => {
     selectConversation(null);
@@ -227,6 +238,7 @@ export default function Home() {
     setShowSettings(false);
     setShowLogs(false);
     setShowBridge(false);
+    setShowResources(false);
   }, [selectConversation]);
 
   // When CascadePanel creates a new cascade, track it
@@ -347,8 +359,8 @@ export default function Home() {
 
   // === Determine what to show in main panel ===
   const showChat = currentConvId !== null || newChatMode;
-  const showConversationList = !showChat && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl && activeWorkspace !== null;
-  const showWelcome = !showChat && !showConversationList && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl;
+  const showConversationList = !showChat && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl && !showResources && activeWorkspace !== null;
+  const showWelcome = !showChat && !showConversationList && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl && !showResources;
 
   return (
     <AuthGate>
@@ -358,6 +370,7 @@ export default function Home() {
           currentConvId={currentConvId}
           conversationsVersion={conversationsVersion}
           activeWorkspace={activeWorkspace}
+          workspaceResources={workspaceResources}
           onSelectWorkspace={handleSelectWorkspace}
           onSelectConversation={handleSelectConversation}
           onShowAccountInfo={handleShowAccountInfo}
@@ -365,6 +378,7 @@ export default function Home() {
           onShowLogs={handleShowLogs}
           onShowBridge={handleShowBridge}
           onShowSourceControl={handleShowSourceControl}
+          onShowResources={handleShowResources}
           onGoHome={handleGoHome}
           onWorkspaceCreated={handleWorkspaceCreated}
           wsVersion={wsVersion}
@@ -539,6 +553,13 @@ export default function Home() {
                   </div>
                 </div>
               )}
+            </div>
+          )}
+
+          {/* Resource Monitor panel */}
+          {showResources && (
+            <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+              <ResourceMonitorView />
             </div>
           )}
 

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { getWorkspaces, createWorkspace, getWorkspaceFolders } from "@/lib/cascade-api"
-import type { Workspace, WorkspaceFolder } from "@/lib/cascade-api"
+import type { Workspace, WorkspaceFolder, WorkspaceResources, ResourceSnapshot } from "@/lib/cascade-api"
 import { cn } from "@/lib/utils"
 import { useTheme } from "@/lib/theme"
 import { PluginManager } from "./plugin-manager"
@@ -43,10 +43,11 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Settings, User, Plug, Book, Globe, Moon, Sun, Plus, FolderOpen, FolderPlus, EllipsisVertical, Activity, Bot, FolderSync, Loader2, Circle, GitBranch } from "lucide-react"
+import { Settings, User, Plug, Book, Globe, Moon, Sun, Plus, FolderOpen, FolderPlus, EllipsisVertical, Activity, Bot, FolderSync, Loader2, Circle, GitBranch, Monitor } from "lucide-react"
 
 import { WorkspaceGroup } from "./sidebar/workspace-group"
 import type { ConvSummary, WorkspaceData } from "./sidebar/workspace-group"
+import { SystemResourceSummary } from "./sidebar/system-resource-summary"
 
 interface AppSidebarProps {
     currentConvId: string | null
@@ -58,8 +59,10 @@ interface AppSidebarProps {
     onShowLogs: () => void
     onShowBridge: () => void
     onShowSourceControl: () => void
+    onShowResources: () => void
     onGoHome: () => void
     activeWorkspace: string | null
+    workspaceResources?: ResourceSnapshot | null
     wsVersion?: number
     onWorkspaceCreated?: () => void
 }
@@ -74,8 +77,10 @@ export function AppSidebar({
     onShowLogs,
     onShowBridge,
     onShowSourceControl,
+    onShowResources,
     onGoHome,
     activeWorkspace,
+    workspaceResources,
     wsVersion,
     onWorkspaceCreated,
 }: AppSidebarProps) {
@@ -290,6 +295,14 @@ export function AppSidebar({
                     </button>
                 </SidebarHeader>
 
+                {/* System Resource Summary — compact CPU/RAM bars */}
+                <div className="px-3 pb-1">
+                    <SystemResourceSummary
+                        system={workspaceResources?.system}
+                        onClick={onShowResources}
+                    />
+                </div>
+
                 <SidebarContent>
                     <SidebarSeparator className="mx-0" />
                     <SidebarGroup>
@@ -305,6 +318,7 @@ export function AppSidebar({
                                         arrayIdx={arrayIdx}
                                         showAll={!!showAllMap[arrayIdx]}
                                         currentConvId={currentConvId}
+                                        resources={workspaceResources?.workspaces?.[wd.workspace.pid]}
                                         onToggleExpand={() => handleWorkspaceClick(arrayIdx)}
                                         onSelectConv={(convId) => handleSelectConv(convId, arrayIdx)}
                                         onToggleShowAll={() => setShowAllMap((prev) => ({ ...prev, [arrayIdx]: true }))}
@@ -376,6 +390,7 @@ export function AppSidebar({
                                                 showAll={!!showAllMap[arrayIdx]}
                                                 currentConvId={currentConvId}
                                                 showActiveIndicator={false}
+                                                resources={workspaceResources?.workspaces?.[wd.workspace.pid]}
                                                 onToggleExpand={() => handleWorkspaceClick(arrayIdx)}
                                                 onSelectConv={(convId) => handleSelectConv(convId, arrayIdx)}
                                                 onToggleShowAll={() => setShowAllMap((prev) => ({ ...prev, [arrayIdx]: true }))}
@@ -433,6 +448,10 @@ export function AppSidebar({
                                     <DropdownMenuItem onClick={onShowSourceControl}>
                                         <GitBranch className="mr-2 h-4 w-4" />
                                         <span>Source Control</span>
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem onClick={onShowResources}>
+                                        <Monitor className="mr-2 h-4 w-4" />
+                                        <span>Resources</span>
                                     </DropdownMenuItem>
                                     <DropdownMenuItem onClick={toggleTheme}>
                                         {isDark ? <Sun className="mr-2 h-4 w-4" /> : <Moon className="mr-2 h-4 w-4" />}

--- a/frontend/components/resource-monitor-view.tsx
+++ b/frontend/components/resource-monitor-view.tsx
@@ -1,0 +1,398 @@
+"use client"
+
+import { useEffect, useState, useCallback, useMemo } from "react"
+import { getWorkspaceResources } from "@/lib/cascade-api"
+import type { ResourceSnapshot, SystemResources, WorkspaceResources, ResourceHistoryPoint, SelfStats } from "@/lib/cascade-api"
+import { Cpu, MemoryStick, Activity, Monitor, HardDrive, Server, Box } from "lucide-react"
+
+// === Donut Chart (SVG) ===
+function DonutChart({ value, max = 100, size = 110, strokeWidth = 10, label, sublabel, color }: {
+    value: number; max?: number; size?: number; strokeWidth?: number
+    label: string; sublabel: string; color: string
+}) {
+    const radius = (size - strokeWidth) / 2
+    const circumference = 2 * Math.PI * radius
+    const percent = Math.min(value / max, 1)
+    const offset = circumference * (1 - percent)
+
+    return (
+        <div className="flex flex-col items-center gap-1.5">
+            <svg width={size} height={size} className="transform -rotate-90">
+                {/* Background ring */}
+                <circle cx={size / 2} cy={size / 2} r={radius}
+                    fill="none" stroke="currentColor" className="text-muted/20"
+                    strokeWidth={strokeWidth} />
+                {/* Value ring */}
+                <circle cx={size / 2} cy={size / 2} r={radius}
+                    fill="none" stroke={color}
+                    strokeWidth={strokeWidth}
+                    strokeDasharray={circumference}
+                    strokeDashoffset={offset}
+                    strokeLinecap="round"
+                    style={{ transition: 'stroke-dashoffset 0.8s ease, stroke 0.8s ease' }} />
+            </svg>
+            {/* Center text overlay */}
+            <div className="absolute flex flex-col items-center justify-center" style={{ width: size, height: size }}>
+                <span className="text-lg font-bold tabular-nums" style={{ color }}>
+                    {value.toFixed(1)}%
+                </span>
+            </div>
+            <span className="text-xs font-medium text-foreground/80">{label}</span>
+            <span className="text-[10px] text-muted-foreground">{sublabel}</span>
+        </div>
+    )
+}
+
+// === Sparkline Chart (SVG) ===
+function Sparkline({ data, width = 280, height = 50, color, label }: {
+    data: number[]; width?: number; height?: number; color: string; label: string
+}) {
+    if (!data.length) return null
+    const max = Math.max(...data, 1)
+    const points = data.map((v, i) => {
+        const x = (i / Math.max(data.length - 1, 1)) * width
+        const y = height - (v / max) * (height - 4) - 2
+        return `${x},${y}`
+    }).join(' ')
+
+    const areaPoints = `0,${height} ${points} ${width},${height}`
+    const latest = data[data.length - 1]
+
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="flex items-center justify-between">
+                <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+                <span className="text-[11px] font-mono tabular-nums" style={{ color }}>
+                    {latest.toFixed(1)}%
+                </span>
+            </div>
+            <svg width={width} height={height} className="w-full" viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+                {/* Fill area */}
+                <polygon points={areaPoints} fill={color} opacity={0.1} />
+                {/* Line */}
+                <polyline points={points} fill="none" stroke={color} strokeWidth={1.5} strokeLinejoin="round" />
+            </svg>
+        </div>
+    )
+}
+
+// === Per-workspace row ===
+function WorkspaceRow({ pid, data }: { pid: string; data: WorkspaceResources }) {
+    const cpuColor = getGradientColor(data.cpuPercent)
+    const memColor = getGradientColor(Math.min((data.memMB / 2048) * 100, 100))
+
+    return (
+        <div className="grid grid-cols-[1fr_100px_100px_60px] items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted/30 transition-colors">
+            <div className="flex items-center gap-2 min-w-0">
+                <Server className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                <span className="text-sm font-medium truncate">{data.name || `PID ${pid}`}</span>
+            </div>
+            <div className="flex items-center gap-2">
+                <div className="w-full h-2 rounded-full bg-muted/30 overflow-hidden">
+                    <div className="h-full rounded-full" style={{
+                        width: `${Math.max(Math.min(data.cpuPercent, 100), 2)}%`,
+                        backgroundColor: cpuColor,
+                        transition: 'width 0.8s ease',
+                    }} />
+                </div>
+                <span className="text-[11px] font-mono tabular-nums text-muted-foreground w-10 text-right">
+                    {data.cpuPercent.toFixed(1)}%
+                </span>
+            </div>
+            <div className="flex items-center gap-2">
+                <div className="w-full h-2 rounded-full bg-muted/30 overflow-hidden">
+                    <div className="h-full rounded-full" style={{
+                        width: `${Math.max(Math.min((data.memMB / 2048) * 100, 100), 2)}%`,
+                        backgroundColor: memColor,
+                        transition: 'width 0.8s ease',
+                    }} />
+                </div>
+                <span className="text-[11px] font-mono tabular-nums text-muted-foreground w-14 text-right">
+                    {data.memMB} MB
+                </span>
+            </div>
+            <span className="text-[10px] text-muted-foreground/60 text-right font-mono">{pid}</span>
+        </div>
+    )
+}
+
+// === Color helper ===
+function getGradientColor(value: number): string {
+    const clamped = Math.max(0, Math.min(100, value))
+    if (clamped < 50) {
+        const t = clamped / 50
+        const h = 142 - t * (142 - 38)
+        return `hsl(${h}, 80%, 48%)`
+    }
+    const t = (clamped - 50) / 50
+    const h = 38 - t * 38
+    return `hsl(${h}, 84%, 55%)`
+}
+
+// === Main Component ===
+export function ResourceMonitorView() {
+    const [snapshot, setSnapshot] = useState<ResourceSnapshot | null>(null)
+    const [loading, setLoading] = useState(true)
+
+
+    const fetchData = useCallback(async () => {
+        try {
+            const data = await getWorkspaceResources()
+            setSnapshot(data)
+        } catch {
+            // ignore — server might not be ready
+        } finally {
+            setLoading(false)
+        }
+    }, [])
+
+    // Fetch on mount + poll every 5s
+    useEffect(() => {
+        fetchData()
+        const timer = setInterval(fetchData, 5000)
+        return () => clearInterval(timer)
+    }, [fetchData])
+
+    // Also listen for WebSocket updates via custom event
+    useEffect(() => {
+        const handler = (e: Event) => {
+            const data = (e as CustomEvent).detail
+            if (data) setSnapshot(data)
+        }
+        window.addEventListener('resource-update', handler)
+        return () => window.removeEventListener('resource-update', handler)
+    }, [])
+
+    const system = snapshot?.system
+    const deckStats = snapshot?.selfStats
+    const workspaces = snapshot?.workspaces || {}
+    const historyData = snapshot?.history || []
+    const workspaceList = useMemo(() =>
+        Object.entries(workspaces).sort((a, b) => b[1].memMB - a[1].memMB),
+        [workspaces]
+    )
+
+    // Aggregate workspace totals
+    const wsTotalCpu = useMemo(() =>
+        workspaceList.reduce((sum, [, w]) => sum + w.cpuPercent, 0),
+        [workspaceList]
+    )
+    const wsTotalMem = useMemo(() =>
+        workspaceList.reduce((sum, [, w]) => sum + w.memMB, 0),
+        [workspaceList]
+    )
+
+    const cpuHistory = useMemo(() => historyData.map(h => h.cpu), [historyData])
+    const memHistory = useMemo(() => historyData.map(h => h.mem), [historyData])
+
+    const cpuColor = system ? getGradientColor(system.cpuPercent) : 'hsl(142, 80%, 48%)'
+    const memColor = system ? getGradientColor(system.memPercent) : 'hsl(142, 80%, 48%)'
+
+    if (loading && !snapshot) {
+        return (
+            <div className="flex-1 flex items-center justify-center">
+                <div className="flex flex-col items-center gap-3">
+                    <Activity className="w-8 h-8 text-muted-foreground/50 animate-pulse" />
+                    <span className="text-sm text-muted-foreground">Loading resource data...</span>
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex-1 overflow-y-auto">
+            <div className="max-w-3xl mx-auto p-6 space-y-6">
+                {/* Header */}
+                <div className="flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-gradient-to-br from-emerald-500/10 to-cyan-500/10 border border-emerald-500/20">
+                        <Monitor className="w-5 h-5 text-emerald-400" />
+                    </div>
+                    <div>
+                        <h2 className="text-lg font-semibold">Resource Monitor</h2>
+                        <p className="text-xs text-muted-foreground">
+                            System: {system?.cpuCores || 0} cores • {system?.memTotalMB ? `${(system.memTotalMB / 1024).toFixed(1)} GB RAM` : '—'}
+                        </p>
+                    </div>
+                </div>
+
+                {/* System Overview — Donut charts */}
+                <div className="rounded-xl border border-border/50 bg-card/50 p-5">
+                    <h3 className="text-sm font-medium text-muted-foreground mb-4 flex items-center gap-2">
+                        <Activity className="w-4 h-4" /> System Overview
+                    </h3>
+                    <div className="grid grid-cols-3 gap-6 justify-items-center">
+                        <div className="relative">
+                            <DonutChart
+                                value={system?.cpuPercent ?? 0}
+                                label="CPU Usage"
+                                sublabel={`${system?.cpuCores ?? 0} cores`}
+                                color={cpuColor}
+                            />
+                        </div>
+                        <div className="relative">
+                            <DonutChart
+                                value={system?.memPercent ?? 0}
+                                label="Memory"
+                                sublabel={`${system?.memUsedMB ? (system.memUsedMB / 1024).toFixed(1) : '0'} / ${system?.memTotalMB ? (system.memTotalMB / 1024).toFixed(1) : '0'} GB`}
+                                color={memColor}
+                            />
+                        </div>
+                        <div className="relative">
+                            <DonutChart
+                                value={workspaceList.length > 0 ? (wsTotalMem / (system?.memUsedMB || 1)) * 100 : 0}
+                                label="Workspace Share"
+                                sublabel={`${workspaceList.length} workspace${workspaceList.length !== 1 ? 's' : ''}`}
+                                color="hsl(262, 80%, 55%)"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Antigravity Deck App — Self Monitoring */}
+                {deckStats && (
+                    <div className="rounded-xl border border-border/50 bg-card/50 p-5">
+                        <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
+                            <Box className="w-4 h-4" /> Antigravity Deck (This App)
+                        </h3>
+                        {/* Column headers */}
+                        <div className="grid grid-cols-[1fr_100px_100px_60px] gap-3 px-3 pb-1 text-[10px] text-muted-foreground/50 uppercase tracking-wider font-medium">
+                            <span>Component</span>
+                            <span>CPU</span>
+                            <span>Memory</span>
+                            <span className="text-right">PID</span>
+                        </div>
+                        <div className="divide-y divide-border/30">
+                            {/* Backend row */}
+                            <div className="grid grid-cols-[1fr_100px_100px_60px] items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted/30 transition-colors">
+                                <div className="flex items-center gap-2 min-w-0">
+                                    <Server className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
+                                    <span className="text-sm font-medium">Backend (Node.js)</span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <div className="w-full h-2 rounded-full bg-muted/30 overflow-hidden">
+                                        <div className="h-full rounded-full" style={{
+                                            width: `${Math.max(Math.min(deckStats.backend.cpuPercent, 100), 2)}%`,
+                                            backgroundColor: getGradientColor(deckStats.backend.cpuPercent),
+                                            transition: 'width 0.8s ease',
+                                        }} />
+                                    </div>
+                                    <span className="text-[11px] font-mono tabular-nums text-muted-foreground w-10 text-right">
+                                        {deckStats.backend.cpuPercent.toFixed(1)}%
+                                    </span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <div className="w-full h-2 rounded-full bg-muted/30 overflow-hidden">
+                                        <div className="h-full rounded-full" style={{
+                                            width: `${Math.max(Math.min((deckStats.backend.memMB / 512) * 100, 100), 2)}%`,
+                                            backgroundColor: getGradientColor(Math.min((deckStats.backend.memMB / 512) * 100, 100)),
+                                            transition: 'width 0.8s ease',
+                                        }} />
+                                    </div>
+                                    <span className="text-[11px] font-mono tabular-nums text-muted-foreground w-14 text-right">
+                                        {deckStats.backend.memMB} MB
+                                    </span>
+                                </div>
+                                <span className="text-[10px] text-muted-foreground/60 text-right font-mono">{deckStats.backend.pid}</span>
+                            </div>
+                            {/* Frontend row */}
+                            <div className="grid grid-cols-[1fr_100px_100px_60px] items-center gap-3 py-2 px-3 rounded-lg hover:bg-muted/30 transition-colors">
+                                <div className="flex items-center gap-2 min-w-0">
+                                    <Monitor className="w-3.5 h-3.5 text-violet-400 shrink-0" />
+                                    <span className="text-sm font-medium">Frontend (Next.js)</span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <div className="w-full h-2 rounded-full bg-muted/30 overflow-hidden">
+                                        <div className="h-full rounded-full" style={{
+                                            width: `${Math.max(Math.min(deckStats.frontend.cpuPercent, 100), 2)}%`,
+                                            backgroundColor: getGradientColor(deckStats.frontend.cpuPercent),
+                                            transition: 'width 0.8s ease',
+                                        }} />
+                                    </div>
+                                    <span className="text-[11px] font-mono tabular-nums text-muted-foreground w-10 text-right">
+                                        {deckStats.frontend.cpuPercent.toFixed(1)}%
+                                    </span>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <div className="w-full h-2 rounded-full bg-muted/30 overflow-hidden">
+                                        <div className="h-full rounded-full" style={{
+                                            width: `${Math.max(Math.min((deckStats.frontend.memMB / 512) * 100, 100), 2)}%`,
+                                            backgroundColor: getGradientColor(Math.min((deckStats.frontend.memMB / 512) * 100, 100)),
+                                            transition: 'width 0.8s ease',
+                                        }} />
+                                    </div>
+                                    <span className="text-[11px] font-mono tabular-nums text-muted-foreground w-14 text-right">
+                                        {deckStats.frontend.memMB} MB
+                                    </span>
+                                </div>
+                                <span className="text-[10px] text-muted-foreground/60 text-right font-mono">{deckStats.frontend.pid || '—'}</span>
+                            </div>
+                        </div>
+                        {/* Totals */}
+                        <div className="grid grid-cols-[1fr_100px_100px_60px] gap-3 px-3 pt-2 mt-2 border-t border-border/50 text-xs font-medium">
+                            <span className="text-muted-foreground">Total Deck</span>
+                            <span className="font-mono tabular-nums">{deckStats.totalCpuPercent.toFixed(1)}%</span>
+                            <span className="font-mono tabular-nums">{deckStats.totalMemMB} MB</span>
+                            <span></span>
+                        </div>
+                    </div>
+                )}
+
+                {/* Usage History — Sparklines */}
+                {cpuHistory.length > 1 && (
+                    <div className="rounded-xl border border-border/50 bg-card/50 p-5">
+                        <h3 className="text-sm font-medium text-muted-foreground mb-4 flex items-center gap-2">
+                            <HardDrive className="w-4 h-4" /> Usage History
+                            <span className="text-[10px] text-muted-foreground/50 ml-auto">Last {Math.round(cpuHistory.length * 5 / 60)} min</span>
+                        </h3>
+                        <div className="space-y-4">
+                            <Sparkline data={cpuHistory} color={cpuColor} label="CPU %" />
+                            <Sparkline data={memHistory} color={memColor} label="Memory %" />
+                        </div>
+                    </div>
+                )}
+
+                {/* Per-workspace Breakdown */}
+                <div className="rounded-xl border border-border/50 bg-card/50 p-5">
+                    <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
+                        <Cpu className="w-4 h-4" /> Workspace Breakdown
+                    </h3>
+
+                    {workspaceList.length === 0 ? (
+                        <div className="text-center py-6">
+                            <Server className="w-6 h-6 mx-auto text-muted-foreground/30 mb-2" />
+                            <p className="text-sm text-muted-foreground/60">No active workspaces detected</p>
+                        </div>
+                    ) : (
+                        <>
+                            {/* Column headers */}
+                            <div className="grid grid-cols-[1fr_100px_100px_60px] gap-3 px-3 pb-1 text-[10px] text-muted-foreground/50 uppercase tracking-wider font-medium">
+                                <span>Workspace</span>
+                                <span>CPU</span>
+                                <span>Memory</span>
+                                <span className="text-right">PID</span>
+                            </div>
+                            <div className="divide-y divide-border/30">
+                                {workspaceList.map(([pid, data]) => (
+                                    <WorkspaceRow key={pid} pid={pid} data={data} />
+                                ))}
+                            </div>
+                            {/* Totals */}
+                            <div className="grid grid-cols-[1fr_100px_100px_60px] gap-3 px-3 pt-2 mt-2 border-t border-border/50 text-xs font-medium">
+                                <span className="text-muted-foreground">Total Antigravity</span>
+                                <span className="font-mono tabular-nums">{wsTotalCpu.toFixed(1)}%</span>
+                                <span className="font-mono tabular-nums">{wsTotalMem} MB</span>
+                                <span></span>
+                            </div>
+                        </>
+                    )}
+                </div>
+
+                {/* Footer info */}
+                <div className="text-center text-[10px] text-muted-foreground/40 pb-4">
+                    Sampling every 5s • {historyData.length} / 60 history points
+                </div>
+            </div>
+        </div>
+    )
+}
+

--- a/frontend/components/sidebar/resource-bar.tsx
+++ b/frontend/components/sidebar/resource-bar.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useMemo } from "react"
+
+export interface ResourceBarProps {
+    cpuPercent: number
+    memMB: number
+}
+
+/** Map a 0–100 value to a gradient color: green → yellow → red */
+function getBarColor(value: number): string {
+    const clamped = Math.max(0, Math.min(100, value))
+    if (clamped < 50) {
+        // green → yellow
+        const t = clamped / 50
+        const h = 142 - t * (142 - 38)  // hue 142 → 38
+        return `hsl(${h}, 80%, 48%)`
+    }
+    // yellow → red
+    const t = (clamped - 50) / 50
+    const h = 38 - t * 38  // hue 38 → 0
+    return `hsl(${h}, 84%, 55%)`
+}
+
+export function ResourceBar({ cpuPercent, memMB }: ResourceBarProps) {
+    // Cap CPU display at 100% for the bar width, but show real value in tooltip
+    const cpuWidth = useMemo(() => Math.min(cpuPercent, 100), [cpuPercent])
+    // RAM: use log scale for bar (most LS processes use 100–2000 MB)
+    // Map 0–2048 MB linearly for the bar width
+    const memWidth = useMemo(() => Math.min((memMB / 2048) * 100, 100), [memMB])
+
+    const cpuColor = useMemo(() => getBarColor(cpuWidth), [cpuWidth])
+    const memColor = useMemo(() => getBarColor(memWidth), [memWidth])
+
+    return (
+        <div
+            className="flex items-center gap-1 shrink-0 ml-1"
+            title={`CPU: ${cpuPercent.toFixed(1)}%  |  RAM: ${memMB} MB`}
+        >
+            {/* CPU bar */}
+            <div className="flex flex-col gap-[2px]">
+                <div className="w-[32px] h-[3px] rounded-full bg-sidebar-foreground/10 overflow-hidden">
+                    <div
+                        className="h-full rounded-full"
+                        style={{
+                            width: `${Math.max(cpuWidth, 2)}%`,
+                            backgroundColor: cpuColor,
+                            transition: 'width 0.8s ease, background-color 0.8s ease',
+                        }}
+                    />
+                </div>
+                {/* RAM bar */}
+                <div className="w-[32px] h-[3px] rounded-full bg-sidebar-foreground/10 overflow-hidden">
+                    <div
+                        className="h-full rounded-full"
+                        style={{
+                            width: `${Math.max(memWidth, 2)}%`,
+                            backgroundColor: memColor,
+                            transition: 'width 0.8s ease, background-color 0.8s ease',
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/components/sidebar/system-resource-summary.tsx
+++ b/frontend/components/sidebar/system-resource-summary.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import type { SystemResources } from "@/lib/cascade-api"
+import { Cpu, MemoryStick } from "lucide-react"
+
+function getBarColor(percent: number): string {
+    const v = Math.max(0, Math.min(100, percent))
+    if (v < 50) { const t = v / 50; return `hsl(${142 - t * 104}, 80%, 48%)` }
+    const t = (v - 50) / 50; return `hsl(${38 - t * 38}, 84%, 55%)`
+}
+
+interface SystemResourceSummaryProps {
+    system: SystemResources | null | undefined
+    onClick?: () => void
+}
+
+export function SystemResourceSummary({ system, onClick }: SystemResourceSummaryProps) {
+    if (!system) return null
+
+    const cpuColor = getBarColor(system.cpuPercent)
+    const memColor = getBarColor(system.memPercent)
+
+    return (
+        <button
+            onClick={onClick}
+            className="w-full px-3 py-2 flex flex-col gap-1.5 rounded-lg bg-sidebar-accent/30 hover:bg-sidebar-accent/60 transition-colors cursor-pointer border border-sidebar-border/30 group"
+            title="Click to open Resource Monitor"
+        >
+            {/* CPU row */}
+            <div className="flex items-center gap-2">
+                <Cpu className="w-3 h-3 text-muted-foreground shrink-0" />
+                <div className="flex-1 h-[5px] rounded-full bg-sidebar-foreground/10 overflow-hidden">
+                    <div className="h-full rounded-full" style={{
+                        width: `${Math.max(system.cpuPercent, 2)}%`,
+                        backgroundColor: cpuColor,
+                        transition: 'width 0.8s ease, background-color 0.8s ease',
+                    }} />
+                </div>
+                <span className="text-[10px] font-mono tabular-nums text-muted-foreground w-[38px] text-right">
+                    {system.cpuPercent.toFixed(1)}%
+                </span>
+            </div>
+            {/* RAM row */}
+            <div className="flex items-center gap-2">
+                <MemoryStick className="w-3 h-3 text-muted-foreground shrink-0" />
+                <div className="flex-1 h-[5px] rounded-full bg-sidebar-foreground/10 overflow-hidden">
+                    <div className="h-full rounded-full" style={{
+                        width: `${Math.max(system.memPercent, 2)}%`,
+                        backgroundColor: memColor,
+                        transition: 'width 0.8s ease, background-color 0.8s ease',
+                    }} />
+                </div>
+                <span className="text-[10px] font-mono tabular-nums text-muted-foreground w-[38px] text-right">
+                    {(system.memUsedMB / 1024).toFixed(1)}G
+                </span>
+            </div>
+        </button>
+    )
+}

--- a/frontend/components/sidebar/workspace-group.tsx
+++ b/frontend/components/sidebar/workspace-group.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { Trash2, ChevronRight, FolderIcon, MessageSquare } from 'lucide-react'
 import { API_BASE } from '@/lib/config'
 import { authHeaders } from '@/lib/auth'
+import { ResourceBar } from './resource-bar'
+import type { WorkspaceResources } from '@/lib/cascade-api'
 import {
     Collapsible,
     CollapsibleContent,
@@ -53,6 +55,7 @@ export function WorkspaceGroup({
     showAll,
     currentConvId,
     showActiveIndicator = true,
+    resources,
     onToggleExpand,
     onSelectConv,
     onToggleShowAll,
@@ -62,6 +65,7 @@ export function WorkspaceGroup({
     showAll: boolean
     currentConvId: string | null
     showActiveIndicator?: boolean
+    resources?: WorkspaceResources
     onToggleExpand: () => void
     onSelectConv: (convId: string) => void
     onToggleShowAll: () => void
@@ -98,6 +102,7 @@ export function WorkspaceGroup({
                             <SidebarMenuButton tooltip={data.workspace.workspaceName} className="text-xs !pr-2">
                                 <FolderIcon className="shrink-0" />
                                 <span className="flex-1 truncate min-w-0">{data.workspace.workspaceName}</span>
+                                {resources && <ResourceBar cpuPercent={resources.cpuPercent} memMB={resources.memMB} />}
                                 <span className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center">
                                     <ChevronRight className="h-4 w-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
                                 </span>

--- a/frontend/lib/cascade-api.ts
+++ b/frontend/lib/cascade-api.ts
@@ -11,6 +11,47 @@ export interface Workspace {
     port: number;
 }
 
+export interface WorkspaceResources {
+    cpuPercent: number;
+    memBytes: number;
+    memMB: number;
+    name?: string;
+}
+
+export interface SystemResources {
+    cpuPercent: number;
+    memUsedMB: number;
+    memTotalMB: number;
+    memPercent: number;
+    cpuCores: number;
+}
+
+export interface ResourceHistoryPoint {
+    t: number;
+    cpu: number;
+    mem: number;
+}
+
+export interface ResourceSnapshot {
+    system: SystemResources;
+    selfStats: SelfStats;
+    workspaces: Record<string, WorkspaceResources>;
+    history: ResourceHistoryPoint[];
+}
+
+export interface SelfProcessStats {
+    pid: number | null;
+    cpuPercent: number;
+    memMB: number;
+}
+
+export interface SelfStats {
+    backend: SelfProcessStats;
+    frontend: SelfProcessStats;
+    totalCpuPercent: number;
+    totalMemMB: number;
+}
+
 export interface CascadeModel {
     label: string;
     modelId: string;
@@ -88,6 +129,13 @@ export async function cascadeSubmit(message: string, modelId?: string, images?: 
 export async function getWorkspaces(): Promise<Workspace[]> {
     const res = await fetch(`${API_BASE}/api/workspaces`, { headers: authHeaders() });
     if (!res.ok) throw new Error(`Workspaces failed: ${res.status}`);
+    return res.json();
+}
+
+// Get CPU/RAM resource stats for all workspace PIDs
+export async function getWorkspaceResources(): Promise<ResourceSnapshot> {
+    const res = await fetch(`${API_BASE}/api/workspaces/resources`, { headers: authHeaders() });
+    if (!res.ok) throw new Error(`Resources failed: ${res.status}`);
     return res.json();
 }
 

--- a/frontend/lib/websocket.ts
+++ b/frontend/lib/websocket.ts
@@ -6,7 +6,8 @@ import { extractStepContent } from './step-utils';
 import { showNotification } from './notifications';
 import { API_BASE, getWsUrl } from './config';
 import { authHeaders, authWsUrl } from './auth';
-import { getCascadeStatus } from './cascade-api';
+import { getCascadeStatus, getWorkspaceResources } from './cascade-api';
+import type { ResourceSnapshot } from './cascade-api';
 
 interface WSState {
     connected: boolean;
@@ -17,6 +18,7 @@ interface WSState {
     lastUpdate: string;
     conversationsVersion: number; // bumped when backend discovers new conversations
     stepContentVersion: number; // bumped on step_updated (streaming content changes)
+    workspaceResources: ResourceSnapshot | null; // full resource snapshot
 }
 
 export function useWebSocket() {
@@ -34,6 +36,7 @@ export function useWebSocket() {
         lastUpdate: '',
         conversationsVersion: 0,
         stepContentVersion: 0,
+        workspaceResources: null,
     });
     const wsRef = useRef<WebSocket | null>(null);
     const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -73,6 +76,10 @@ export function useWebSocket() {
                 if (convId && ws.readyState === 1) {
                     ws.send(JSON.stringify({ type: 'set_conversation', conversationId: convId }));
                 }
+                // Fetch initial resource data immediately (don't wait for first 5s broadcast)
+                getWorkspaceResources()
+                    .then(data => setState(prev => ({ ...prev, workspaceResources: data })))
+                    .catch(() => { /* ignore — resource monitor may not be ready */ });
             };
 
             ws.onmessage = (event) => {
@@ -152,6 +159,9 @@ export function useWebSocket() {
                         // Backend discovered new conversations — bump version to trigger sidebar refresh
                         console.log('[WS] conversations_updated — refreshing sidebar');
                         setState(prev => ({ ...prev, conversationsVersion: prev.conversationsVersion + 1 }));
+                    } else if (data.type === 'workspace_resources') {
+                        // Resource monitor broadcast — update workspace CPU/RAM stats
+                        setState(prev => ({ ...prev, workspaceResources: data.data || {} }));
                     }
                 } catch (e) {
                     console.error('WS parse error:', e);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -9,6 +9,16 @@ const nextConfig: NextConfig = {
   poweredByHeader: false,
   devIndicators: false, // hide the floating Next.js "N" logo
 
+  // Allow long-running backend responses (e.g. workspace create waits up to 30s for LS detection)
+  experimental: {
+    proxyTimeout: 60_000, // 60s proxy timeout (default is ~30s)
+  },
+
+  // Keep backend connections alive for efficiency
+  httpAgentOptions: {
+    keepAlive: true,
+  },
+
   // Proxy /api/* and /ws/* to Express backend — works on any OS, no CORS ever
   async rewrites() {
     return [

--- a/server.js
+++ b/server.js
@@ -62,6 +62,8 @@ setupWebSocket(wss);
 server.listen(PORT, async () => {
   console.log(`\n  💬 Chat Mirror v2 (API) running at http://localhost:${PORT}\n`);
   await init(() => startPolling());
+  const { startResourceMonitor } = require('./src/resource-monitor');
+  startResourceMonitor();
   startAutoRescan();
 
   // Auto-start Agent Bridge if configured in settings.json

--- a/src/resource-monitor.js
+++ b/src/resource-monitor.js
@@ -1,0 +1,377 @@
+// === Per-Workspace Resource Monitor ===
+// Samples CPU% and RAM for each language_server process (by PID).
+// Also tracks system-level CPU/RAM for overview dashboard.
+// Cross-platform: Windows (PowerShell) + macOS/Linux (ps).
+
+const { exec } = require('child_process');
+const os = require('os');
+const path = require('path');
+const { lsInstances, platform } = require('./config');
+
+const SAMPLE_INTERVAL = 5000; // 5 seconds
+const HISTORY_SIZE = 60;      // 60 samples = 5 minutes of history
+const NUM_CPUS = os.cpus().length;
+const TOTAL_MEM_MB = Math.round(os.totalmem() / 1024 / 1024);
+
+// --- State ---
+let monitorTimer = null;
+const resourceData = new Map(); // pid → { cpuPercent, memBytes, memMB }
+const prevCpuTimes = new Map(); // pid → { totalMs, timestamp } (Windows CPU delta tracking)
+
+// System-level stats
+let systemStats = { cpuPercent: 0, memUsedMB: 0, memTotalMB: TOTAL_MEM_MB, memPercent: 0 };
+
+// Self-monitoring stats (Antigravity Deck app)
+let selfStats = {
+    backend: { pid: process.pid, cpuPercent: 0, memMB: 0 },
+    frontend: { pid: null, cpuPercent: 0, memMB: 0 },
+    totalCpuPercent: 0,
+    totalMemMB: 0,
+};
+let prevSelfCpu = process.cpuUsage();
+let prevSelfTs = Date.now();
+let frontendPid = null; // cached Next.js process PID
+
+// History ring buffer: array of { timestamp, system, workspaces }
+const history = [];
+
+// Previous system CPU idle/total for delta calculation
+let prevSystemCpu = null;
+
+// --- System-level CPU (cross-platform) ---
+
+function getSystemCpuPercent() {
+    const cpus = os.cpus();
+    let totalIdle = 0, totalTick = 0;
+    for (const cpu of cpus) {
+        for (const type in cpu.times) totalTick += cpu.times[type];
+        totalIdle += cpu.times.idle;
+    }
+    if (prevSystemCpu) {
+        const idleDelta = totalIdle - prevSystemCpu.idle;
+        const totalDelta = totalTick - prevSystemCpu.total;
+        const cpuPercent = totalDelta > 0 ? Math.round((1 - idleDelta / totalDelta) * 1000) / 10 : 0;
+        prevSystemCpu = { idle: totalIdle, total: totalTick };
+        return Math.max(0, Math.min(100, cpuPercent));
+    }
+    prevSystemCpu = { idle: totalIdle, total: totalTick };
+    return 0; // first call, no delta
+}
+
+function getSystemMemory() {
+    const freeMem = os.freemem();
+    const totalMem = os.totalmem();
+    const usedMem = totalMem - freeMem;
+    return {
+        memUsedMB: Math.round(usedMem / 1024 / 1024),
+        memTotalMB: Math.round(totalMem / 1024 / 1024),
+        memPercent: Math.round((usedMem / totalMem) * 1000) / 10,
+    };
+}
+
+// --- Cross-platform process stats ---
+
+/**
+ * Windows: batch query all PIDs using PowerShell Get-Process.
+ */
+async function getStatsWindows(pids) {
+    if (!pids.length) return new Map();
+
+    return new Promise((resolve) => {
+        const pidList = pids.join(',');
+        const ps = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+        const cmd = `"${ps}" -NoProfile -Command "Get-Process -Id ${pidList} -ErrorAction SilentlyContinue | Select-Object Id, CPU, WorkingSet64 | ConvertTo-Json -Compress"`;
+
+        exec(cmd, { timeout: 8000 }, (err, stdout) => {
+            const result = new Map();
+            if (err || !stdout.trim()) { resolve(result); return; }
+
+            try {
+                let procs = JSON.parse(stdout.trim());
+                if (!Array.isArray(procs)) procs = [procs];
+                const now = Date.now();
+
+                for (const proc of procs) {
+                    if (!proc || !proc.Id) continue;
+                    const pid = String(proc.Id);
+                    const totalCpuSeconds = proc.CPU || 0;
+                    const memBytes = proc.WorkingSet64 || 0;
+
+                    let cpuPercent = 0;
+                    const prev = prevCpuTimes.get(pid);
+                    if (prev) {
+                        const elapsedMs = now - prev.timestamp;
+                        if (elapsedMs > 0) {
+                            const deltaCpuMs = (totalCpuSeconds * 1000) - prev.totalMs;
+                            cpuPercent = Math.max(0, (deltaCpuMs / elapsedMs) * 100);
+                            cpuPercent = Math.min(cpuPercent, NUM_CPUS * 100);
+                        }
+                    }
+                    prevCpuTimes.set(pid, { totalMs: totalCpuSeconds * 1000, timestamp: now });
+
+                    result.set(pid, {
+                        cpuPercent: Math.round(cpuPercent * 10) / 10,
+                        memBytes,
+                        memMB: Math.round(memBytes / 1024 / 1024),
+                    });
+                }
+            } catch { }
+            resolve(result);
+        });
+    });
+}
+
+/**
+ * macOS/Linux: query using ps command.
+ */
+async function getStatsUnix(pids) {
+    if (!pids.length) return new Map();
+
+    return new Promise((resolve) => {
+        const pidList = pids.join(',');
+        const cmd = `ps -p ${pidList} -o pid,%cpu,rss --no-headers 2>/dev/null`;
+
+        exec(cmd, { timeout: 5000 }, (err, stdout) => {
+            const result = new Map();
+            if (err || !stdout.trim()) { resolve(result); return; }
+
+            stdout.split('\n').forEach(line => {
+                const parts = line.trim().split(/\s+/);
+                if (parts.length < 3) return;
+                const [pid, cpuStr, rssStr] = parts;
+                const cpuPercent = parseFloat(cpuStr) || 0;
+                const rssKB = parseInt(rssStr) || 0;
+                const memBytes = rssKB * 1024;
+
+                result.set(pid, {
+                    cpuPercent: Math.round(cpuPercent * 10) / 10,
+                    memBytes,
+                    memMB: Math.round(memBytes / 1024 / 1024),
+                });
+            });
+            resolve(result);
+        });
+    });
+}
+
+/**
+ * Get child process PIDs for a parent PID.
+ */
+async function getChildPids(parentPid) {
+    return new Promise((resolve) => {
+        let cmd;
+        if (platform === 'win32') {
+            const ps = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+            cmd = `"${ps}" -NoProfile -Command "Get-CimInstance Win32_Process -Filter \\"ParentProcessId=${parentPid}\\" | Select-Object ProcessId | ConvertTo-Json -Compress"`;
+        } else {
+            cmd = `pgrep -P ${parentPid} 2>/dev/null`;
+        }
+
+        exec(cmd, { timeout: 5000 }, (err, stdout) => {
+            if (err || !stdout.trim()) { resolve([]); return; }
+            const childPids = [];
+            if (platform === 'win32') {
+                try {
+                    let items = JSON.parse(stdout.trim());
+                    if (!Array.isArray(items)) items = [items];
+                    items.forEach(item => { if (item && item.ProcessId) childPids.push(String(item.ProcessId)); });
+                } catch { }
+            } else {
+                stdout.trim().split('\n').forEach(line => { const pid = line.trim(); if (pid) childPids.push(pid); });
+            }
+            resolve(childPids);
+        });
+    });
+}
+
+/**
+ * Main sampling tick.
+ */
+async function sampleAll() {
+    // --- System stats (always, even with no workspaces) ---
+    const cpuPercent = getSystemCpuPercent();
+    const mem = getSystemMemory();
+    systemStats = { cpuPercent, ...mem };
+
+    // --- Self-monitoring: backend Node.js process ---
+    const nowTs = Date.now();
+    const currentCpu = process.cpuUsage();
+    const elapsedUs = (nowTs - prevSelfTs) * 1000; // ms → µs
+    const userDelta = currentCpu.user - prevSelfCpu.user;
+    const sysDelta = currentCpu.system - prevSelfCpu.system;
+    const beCpuPercent = elapsedUs > 0
+        ? Math.round(((userDelta + sysDelta) / elapsedUs) * 1000) / 10
+        : 0;
+    prevSelfCpu = currentCpu;
+    prevSelfTs = nowTs;
+    const beMemMB = Math.round(process.memoryUsage().rss / 1024 / 1024);
+
+    // --- Self-monitoring: frontend Next.js process ---
+    let feCpuPercent = 0, feMemMB = 0;
+    try {
+        // Find frontend process: look for node processes running 'next'
+        if (!frontendPid) {
+            frontendPid = await findFrontendPid();
+        }
+        if (frontendPid) {
+            const fePids = [String(frontendPid)];
+            // Also get FE child processes (Next.js workers)
+            const feChildren = await getChildPids(String(frontendPid));
+            fePids.push(...feChildren);
+            // Get all FE-related PIDs' stats including grandchildren
+            const allFePids = [...fePids];
+            for (const cp of feChildren) {
+                const grandchildren = await getChildPids(cp);
+                allFePids.push(...grandchildren);
+            }
+            const feStats = platform === 'win32'
+                ? await getStatsWindows(allFePids)
+                : await getStatsUnix(allFePids);
+            for (const [, s] of feStats) {
+                feCpuPercent += s.cpuPercent;
+                feMemMB += s.memMB;
+            }
+        }
+    } catch { }
+
+    selfStats = {
+        backend: { pid: process.pid, cpuPercent: Math.max(0, beCpuPercent), memMB: beMemMB },
+        frontend: { pid: frontendPid, cpuPercent: Math.round(feCpuPercent * 10) / 10, memMB: feMemMB },
+        totalCpuPercent: Math.round((beCpuPercent + feCpuPercent) * 10) / 10,
+        totalMemMB: beMemMB + feMemMB,
+    };
+
+    // --- Per-workspace stats ---
+    const pids = lsInstances.map(inst => String(inst.pid));
+
+    if (pids.length > 0) {
+        const childMap = new Map();
+        const allPids = new Set(pids);
+
+        try {
+            await Promise.all(pids.map(async (pid) => {
+                const children = await getChildPids(pid);
+                childMap.set(pid, children);
+                children.forEach(c => allPids.add(c));
+            }));
+        } catch { }
+
+        const allPidArray = [...allPids];
+        const statsMap = platform === 'win32'
+            ? await getStatsWindows(allPidArray)
+            : await getStatsUnix(allPidArray);
+
+        for (const parentPid of pids) {
+            const parentStats = statsMap.get(parentPid) || { cpuPercent: 0, memBytes: 0, memMB: 0 };
+            const children = childMap.get(parentPid) || [];
+            let totalCpu = parentStats.cpuPercent;
+            let totalMem = parentStats.memBytes;
+
+            for (const childPid of children) {
+                const childStats = statsMap.get(childPid);
+                if (childStats) { totalCpu += childStats.cpuPercent; totalMem += childStats.memBytes; }
+            }
+
+            resourceData.set(parentPid, {
+                cpuPercent: Math.round(totalCpu * 10) / 10,
+                memBytes: totalMem,
+                memMB: Math.round(totalMem / 1024 / 1024),
+            });
+        }
+
+        // Clean up stale PIDs
+        for (const pid of resourceData.keys()) {
+            if (!pids.includes(pid)) { resourceData.delete(pid); prevCpuTimes.delete(pid); }
+        }
+    }
+
+    // --- Push to history ring buffer ---
+    const workspaces = {};
+    for (const [pid, stats] of resourceData) {
+        const inst = lsInstances.find(i => String(i.pid) === pid);
+        workspaces[pid] = { ...stats, name: inst?.workspaceName || pid };
+    }
+
+    history.push({
+        timestamp: Date.now(),
+        system: { ...systemStats },
+        workspaces,
+    });
+    if (history.length > HISTORY_SIZE) history.shift();
+
+    // --- Broadcast ---
+    try {
+        const { broadcastAll } = require('./ws');
+        broadcastAll({ type: 'workspace_resources', data: getResourceSnapshot() });
+    } catch { }
+}
+
+/**
+ * Full snapshot: system + per-workspace + history.
+ */
+function getResourceSnapshot() {
+    const workspaces = {};
+    for (const [pid, stats] of resourceData) {
+        const inst = lsInstances.find(i => String(i.pid) === pid);
+        workspaces[pid] = { ...stats, name: inst?.workspaceName || pid };
+    }
+
+    return {
+        system: { ...systemStats, cpuCores: NUM_CPUS },
+        selfStats: { ...selfStats },
+        workspaces,
+        history: history.map(h => ({
+            t: h.timestamp,
+            cpu: h.system.cpuPercent,
+            mem: h.system.memPercent,
+        })),
+    };
+}
+
+/**
+ * Start the resource monitoring loop.
+ */
+function startResourceMonitor() {
+    if (monitorTimer) return;
+    console.log(`[*] Resource monitor started (interval: ${SAMPLE_INTERVAL / 1000}s, CPUs: ${NUM_CPUS}, RAM: ${TOTAL_MEM_MB}MB)`);
+    // Initial sample after a short delay
+    setTimeout(() => {
+        sampleAll();
+        monitorTimer = setInterval(sampleAll, SAMPLE_INTERVAL);
+    }, 2000);
+}
+
+module.exports = { startResourceMonitor, getResourceSnapshot };
+
+/**
+ * Find the frontend Next.js process PID.
+ * Strategy: find node processes with 'next' in command line.
+ */
+async function findFrontendPid() {
+    return new Promise((resolve) => {
+        if (platform === 'win32') {
+            const ps = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+            const cmd = `"${ps}" -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -like '*next*dev*' } | Select-Object ProcessId | ConvertTo-Json -Compress"`;
+            exec(cmd, { timeout: 8000 }, (err, stdout) => {
+                if (err || !stdout.trim()) { resolve(null); return; }
+                try {
+                    let items = JSON.parse(stdout.trim());
+                    if (!Array.isArray(items)) items = [items];
+                    // Return the first match
+                    if (items.length > 0 && items[0].ProcessId) {
+                        resolve(items[0].ProcessId);
+                        return;
+                    }
+                } catch { }
+                resolve(null);
+            });
+        } else {
+            // macOS/Linux: find node processes with 'next' in args
+            exec('pgrep -f "next.*dev" 2>/dev/null', { timeout: 5000 }, (err, stdout) => {
+                if (err || !stdout.trim()) { resolve(null); return; }
+                const pid = parseInt(stdout.trim().split('\n')[0]);
+                resolve(pid || null);
+            });
+        }
+    });
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -216,6 +216,13 @@ function setupRoutes(app) {
         res.json({ root, folders: entries });
     });
 
+    // Resource usage snapshot for all workspace PIDs
+    app.get('/api/workspaces/resources', (req, res) => {
+        const { getResourceSnapshot } = require('./resource-monitor');
+        res.json(getResourceSnapshot());
+    });
+
+
     // --- resolveInst: determine which LS instance to route a request to ---
     function resolveInst(req) {
         // 1. By cascade ID (existing cascades)
@@ -348,11 +355,13 @@ function setupRoutes(app) {
 
             child.unref();
         } else {
-            // Windows/Linux: use spawn instead of exec
+            // Windows/Linux: use spawn with shell:true on Windows (.cmd files need shell)
+            const { platform } = require('./config');
             const child = spawn('antigravity', ['--trust-workspace', folderPath], {
                 timeout: 10000,
                 detached: true,
-                stdio: 'ignore'
+                stdio: 'ignore',
+                shell: platform === 'win32', // Windows .cmd files require shell
             });
 
             child.on('error', (err) => {


### PR DESCRIPTION
## Summary
Add a full-stack Resource Monitor feature that tracks CPU and memory usage for each workspace language-server process in real-time.

## Backend Changes
- **[NEW] src/resource-monitor.js**: Cross-platform resource monitor (378 lines)
  - Samples CPU% and RAM for each LS process by PID (Windows via PowerShell, macOS/Linux via ps command)
  - Tracks system-level CPU/RAM for overview dashboard
  - Maintains a sliding-window history ring buffer (60 data points)
  - Tracks self-process stats (backend + frontend Node.js processes)
  - Broadcasts snapshots via WebSocket every 5 seconds
- **src/routes.js**: Add GET /api/workspaces/resources endpoint
  - Returns full resource snapshot (system, self, per-workspace, history)
  - Fix Windows spawn: add shell:true for .cmd files (antigravity CLI)
- **server.js**: Start resource monitor on server boot

## Frontend Changes
- **[NEW] frontend/components/resource-monitor-view.tsx**: Full Resource Monitor panel
  - System overview cards (CPU, RAM, Deck processes)
  - Per-workspace resource breakdown with live bars
  - Real-time history chart (last 5 minutes)
- **[NEW] frontend/components/sidebar/resource-bar.tsx**: Compact CPU/RAM bar component
  - Green → yellow → red gradient based on usage level
  - Displayed inline next to each workspace in sidebar
- **[NEW] frontend/components/sidebar/system-resource-summary.tsx**: System resource widget
  - Compact CPU/RAM bars shown at top of sidebar
  - Clickable to open full Resource Monitor view
- **frontend/lib/cascade-api.ts**: Add TypeScript interfaces for resource data (WorkspaceResources, SystemResources, ResourceSnapshot, SelfStats, etc.)
- **frontend/lib/websocket.ts**: Handle workspace_resources WebSocket events
  - Fetch initial snapshot on connect, then receive 5s broadcasts
- **frontend/app/page.tsx**: Wire up ResourceMonitorView panel + state
- **frontend/components/app-sidebar.tsx**: Add resource summary widget and Resources menu item
- **frontend/components/sidebar/workspace-group.tsx**: Show per-workspace ResourceBar

## Config Changes
- **frontend/next.config.ts**: Add proxyTimeout (60s) and httpAgentOptions.keepAlive