### PR TITLE
Feat/headless ls

### DIFF
--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -98,6 +98,7 @@ export function AppSidebar({
     const [showCreateDialog, setShowCreateDialog] = useState(false)
     const [showAllMap, setShowAllMap] = useState<Record<string, boolean>>({})
     const [headlessMode, setHeadlessMode] = useState(false)
+    const [selectedFolder, setSelectedFolder] = useState<WorkspaceFolder | null>(null)
 
     // User profile state
     const [userProfile, setUserProfile] = useState<{ name: string; tier: string; avatar: string | null } | null>(null)
@@ -359,28 +360,19 @@ export function AppSidebar({
                                 <SidebarGroupContent>
                                     <SidebarMenu>
                                         {closedFolders.map((folder) => (
-                                            <SidebarMenuItem key={folder.name} className="group/avail">
+                                            <SidebarMenuItem key={folder.name}>
                                                 <SidebarMenuButton
-                                                    onClick={() => handleOpenFolder(folder)}
+                                                    onClick={() => setSelectedFolder(folder)}
                                                     disabled={openingFolder === folder.name}
                                                     tooltip={folder.name}
                                                     className="text-xs !pr-2"
                                                 >
                                                     <FolderOpen className="shrink-0" />
                                                     <span className="flex-1 truncate min-w-0">{folder.name}</span>
-                                                    <span className="ml-auto opacity-0 group-hover/avail:opacity-100 text-[9px] text-muted-foreground/50 transition-opacity shrink-0">
+                                                    <span className="ml-auto opacity-0 group-hover/menu-item:opacity-100 text-[9px] text-muted-foreground/50 transition-opacity shrink-0">
                                                         {openingFolder === folder.name ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Open'}
                                                     </span>
                                                 </SidebarMenuButton>
-                                                {openingFolder !== folder.name && (
-                                                    <button
-                                                        onClick={(e) => { e.stopPropagation(); handleOpenFolderHeadless(folder) }}
-                                                        title="Open Headless (no IDE)"
-                                                        className="absolute right-7 top-1/2 -translate-y-1/2 opacity-0 group-hover/avail:opacity-100 transition-opacity w-6 h-6 rounded-md flex items-center justify-center text-muted-foreground/40 hover:text-emerald-400 hover:bg-emerald-400/10"
-                                                    >
-                                                        <Terminal className="h-3.5 w-3.5" />
-                                                    </button>
-                                                )}
                                             </SidebarMenuItem>
                                         ))}
                                     </SidebarMenu>
@@ -595,6 +587,50 @@ export function AppSidebar({
                             {headlessMode ? 'Create Headless' : 'Create Workspace'}
                         </Button>
                     </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={!!selectedFolder} onOpenChange={(open) => { if (!open) setSelectedFolder(null) }}>
+                <DialogContent className="sm:max-w-[380px]">
+                    <DialogHeader>
+                        <DialogTitle className="flex items-center gap-2">
+                            <FolderOpen className="h-5 w-5" />
+                            Open Workspace
+                        </DialogTitle>
+                        <DialogDescription>
+                            Choose how to open <span className="font-medium text-foreground">{selectedFolder?.name}</span>
+                        </DialogDescription>
+                    </DialogHeader>
+
+                    <div className="grid grid-cols-2 gap-3 py-2">
+                        <button
+                            onClick={() => { if (selectedFolder) { handleOpenFolder(selectedFolder); setSelectedFolder(null) } }}
+                            disabled={openingFolder === selectedFolder?.name}
+                            className="flex flex-col items-center gap-2.5 rounded-xl border border-border/50 bg-card/50 p-4 hover:bg-blue-500/5 hover:border-blue-500/30 transition-all cursor-pointer group"
+                        >
+                            <div className="p-2.5 rounded-lg bg-blue-500/10 border border-blue-500/20 group-hover:bg-blue-500/15 transition-colors">
+                                <FolderOpen className="h-5 w-5 text-blue-400" />
+                            </div>
+                            <div className="text-center">
+                                <p className="text-sm font-medium">Open with IDE</p>
+                                <p className="text-[10px] text-muted-foreground mt-0.5">Full Antigravity editor</p>
+                            </div>
+                        </button>
+
+                        <button
+                            onClick={() => { if (selectedFolder) { handleOpenFolderHeadless(selectedFolder); setSelectedFolder(null) } }}
+                            disabled={openingFolder === selectedFolder?.name}
+                            className="flex flex-col items-center gap-2.5 rounded-xl border border-border/50 bg-card/50 p-4 hover:bg-emerald-500/5 hover:border-emerald-500/30 transition-all cursor-pointer group"
+                        >
+                            <div className="p-2.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20 group-hover:bg-emerald-500/15 transition-colors">
+                                <Terminal className="h-5 w-5 text-emerald-400" />
+                            </div>
+                            <div className="text-center">
+                                <p className="text-sm font-medium">Open Headless</p>
+                                <p className="text-[10px] text-muted-foreground mt-0.5">No IDE UI — agent mode</p>
+                            </div>
+                        </button>
+                    </div>
                 </DialogContent>
             </Dialog>
         </>


### PR DESCRIPTION
## 🎯 feat: Open workspace dialog with IDE/Headless options

Clicking an available workspace now opens a **chooser dialog** instead of directly launching the IDE.

### UI
The dialog presents two side-by-side option cards:

| Option | Icon | Description |
|--------|------|-------------|
| **Open with IDE** | 📁 FolderOpen (blue) | Full Antigravity editor UI |
| **Open Headless** | 💻 Terminal (green) | No IDE UI — agent/background mode |

Each card has hover effects (border highlight + background tint) for clear visual feedback.

### Flow
1. User clicks workspace name in **Available Workspaces**
2. Dialog pops with workspace name in description
3. User picks an option → dialog closes → workspace starts loading
4. Loading spinner appears on the workspace item while opening

### Files
| File | Change |
|------|--------|
| `app-sidebar.tsx` | Added `selectedFolder` state, replaced direct click with dialog, new `Dialog` with 2 option cards |