### PR TITLE
feat: simplify Account & Plan view — show model usage & real reset time

### DIFF
--- a/frontend/components/user-profile.tsx
+++ b/frontend/components/user-profile.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { API_BASE } from '@/lib/config';
 import { authHeaders } from '@/lib/auth';
 import { cn } from '@/lib/utils';
@@ -7,10 +7,8 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { ImageIcon, User, RefreshCw, MessageSquare, RefreshCcw } from 'lucide-react';
-import { CreditCard } from './profile/credit-card';
-import { FeatureBadge } from './profile/feature-badge';
-import { CollapsibleSection } from './profile/collapsible-section';
+import { User, RefreshCw, Calendar, Clock, Zap } from 'lucide-react';
+
 export function UserProfile() {
     const [user, setUser] = useState<any>(null);
     const [profilePic, setProfilePic] = useState<string | null>(null);
@@ -57,40 +55,47 @@ export function UserProfile() {
     );
 }
 
-// === Full Account Info View — shown in main panel (Profile only, no settings) ===
+// === Account & Plan View — shows subscription, model usage, and reset timing ===
+
 interface Model {
     label: string;
     modelId: string;
     supportsImages: boolean;
     isRecommended: boolean;
     quota: number;
+    resetTime: string | null;
+}
+
+/** Format a countdown string like "21d 7h" */
+function formatCountdown(target: Date): string {
+    const diff = target.getTime() - Date.now();
+    if (diff <= 0) return 'Resetting soon...';
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+    const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    if (days > 0) return `${days}d ${hours}h`;
+    const mins = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+    return `${hours}h ${mins}m`;
 }
 
 export function AccountInfoView() {
     const [user, setUser] = useState<any>(null);
-    const [rawUserData, setRawUserData] = useState<any>(null);
     const [profilePic, setProfilePic] = useState<string | null>(null);
     const [models, setModels] = useState<Model[]>([]);
-    const [defaultModel, setDefaultModel] = useState('');
     const [loading, setLoading] = useState(true);
+    const [now, setNow] = useState(Date.now());
 
-    const loadAll = useCallback(async () => {
+    const loadData = useCallback(async () => {
         setLoading(true);
         try {
-            const [profileRes, userRes, modelsRes] = await Promise.all([
+            const [profileRes, modelsRes] = await Promise.all([
                 fetch(`${API_BASE}/api/user/profile`, { headers: authHeaders() }),
-                fetch(`${API_BASE}/api/user`, { headers: authHeaders() }),
                 fetch(`${API_BASE}/api/models`, { headers: authHeaders() }),
             ]);
             const profileData = await profileRes.json();
-            const userData = await userRes.json();
             const modelsData = await modelsRes.json();
-
             setUser(profileData.user || {});
-            setRawUserData(userData);
             if (profileData.profilePicture) setProfilePic(profileData.profilePicture);
             setModels(modelsData.models || []);
-            setDefaultModel(modelsData.defaultModel || '');
         } catch (e) {
             console.error('Failed to load account data:', e);
         } finally {
@@ -98,145 +103,150 @@ export function AccountInfoView() {
         }
     }, []);
 
-    useEffect(() => { loadAll(); }, [loadAll]);
+    useEffect(() => { loadData(); }, [loadData]);
+
+    // Tick every minute for countdown
+    useEffect(() => {
+        const timer = setInterval(() => setNow(Date.now()), 60_000);
+        return () => clearInterval(timer);
+    }, []);
+
+    // Use the earliest resetTime from loaded models
+    const resetDate = useMemo(() => {
+        const times = models
+            .map(m => m.resetTime)
+            .filter((t): t is string => !!t)
+            .map(t => new Date(t).getTime())
+            .filter(t => t > Date.now());
+        return times.length > 0 ? new Date(Math.min(...times)) : null;
+    }, [models]);
+    const countdown = useMemo(() => resetDate ? formatCountdown(resetDate) : '—', [now, resetDate]);
+    const resetDateStr = useMemo(() => resetDate ? resetDate.toLocaleString('en-US', {
+        month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit'
+    }) : 'Unknown', [resetDate]);
 
     if (loading) {
         return (
             <div className="flex-1 overflow-y-auto">
-                <div className="max-w-2xl mx-auto p-6 space-y-4">
-                    <Skeleton className="h-6 w-20" />
-                    <Skeleton className="h-20 w-full rounded-lg" />
-                    <div className="grid grid-cols-2 gap-3">
-                        <Skeleton className="h-24 rounded-lg" />
-                        <Skeleton className="h-24 rounded-lg" />
-                    </div>
-                    <Skeleton className="h-40 w-full rounded-lg" />
+                <div className="max-w-xl mx-auto p-6 space-y-4">
+                    <Skeleton className="h-6 w-32" />
+                    <Skeleton className="h-24 w-full rounded-xl" />
+                    <Skeleton className="h-40 w-full rounded-xl" />
+                    <Skeleton className="h-16 w-full rounded-xl" />
                 </div>
             </div>
         );
     }
 
-    const promptCredits = user?.planStatus?.availablePromptCredits ?? 0;
-    const maxPromptCredits = user?.planStatus?.planInfo?.monthlyPromptCredits ?? 1;
-    const promptPct = maxPromptCredits > 0 ? Math.min(100, Math.round((promptCredits / maxPromptCredits) * 100)) : 0;
-
-    const flowCredits = user?.planStatus?.availableFlowCredits ?? 0;
-    const maxFlowCredits = user?.planStatus?.planInfo?.monthlyFlowCredits ?? 1;
-    const flowPct = maxFlowCredits > 0 ? Math.min(100, Math.round((flowCredits / maxFlowCredits) * 100)) : 0;
-
-    const planInfo = user?.planStatus?.planInfo || {};
     const tierName = user?.userTier?.name || '';
-    const planName = planInfo.planName || '';
+    const planName = user?.planStatus?.planInfo?.planName || '';
 
     return (
         <div className="flex-1 overflow-y-auto">
-            <div className="max-w-2xl mx-auto p-6 space-y-6">
+            <div className="max-w-xl mx-auto p-6 space-y-5">
 
                 {/* Header */}
                 <div className="flex items-center gap-2">
-                    <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5"><User className="h-3.5 w-3.5" /> Profile</h2>
+                    <h2 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-1.5">
+                        <Zap className="h-3.5 w-3.5" /> Account & Plan
+                    </h2>
                     <div className="flex-1 h-px bg-border/30" />
-                    <Button variant="outline" size="sm" onClick={loadAll} className="h-7 text-[10px]">
+                    <Button variant="outline" size="sm" onClick={loadData} className="h-7 text-[10px]">
                         <RefreshCw className="h-3 w-3" /> Refresh
                     </Button>
                 </div>
 
-                {/* Profile header */}
-                <div className="flex items-center gap-4">
-                    <Avatar className="w-14 h-14 rounded-full">
-                        {profilePic && <AvatarImage src={`data:image/png;base64,${profilePic}`} alt={user?.name} />}
-                        <AvatarFallback className="rounded-full bg-primary/15 text-xl font-semibold text-primary">
-                            {user?.name?.[0]?.toUpperCase() || '?'}
-                        </AvatarFallback>
-                    </Avatar>
-                    <div className="flex-1 min-w-0">
-                        <div className="text-base font-semibold">{user?.name || 'User'}</div>
-                        {user?.email && <p className="text-xs text-muted-foreground">{user.email}</p>}
-                        <div className="flex items-center gap-2 mt-1.5">
-                            {tierName && <Badge variant="secondary">{tierName}</Badge>}
-                            {planName && <Badge variant="outline">{planName} Plan</Badge>}
+                {/* Subscription Card */}
+                <div className="relative overflow-hidden rounded-xl border border-border/50 bg-gradient-to-br from-indigo-500/10 via-purple-500/5 to-transparent p-5">
+                    <div className="absolute top-0 right-0 w-32 h-32 bg-indigo-500/5 rounded-full -translate-y-1/2 translate-x-1/2" />
+                    <div className="flex items-center gap-4 relative">
+                        <Avatar className="w-12 h-12 rounded-full ring-2 ring-indigo-500/20">
+                            {profilePic && <AvatarImage src={`data:image/png;base64,${profilePic}`} alt={user?.name} />}
+                            <AvatarFallback className="rounded-full bg-indigo-500/20 text-lg font-bold text-indigo-400">
+                                {user?.name?.[0]?.toUpperCase() || '?'}
+                            </AvatarFallback>
+                        </Avatar>
+                        <div className="flex-1 min-w-0">
+                            <div className="text-base font-semibold">{user?.name || 'User'}</div>
+                            {user?.email && <p className="text-xs text-muted-foreground truncate">{user.email}</p>}
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-2 mt-3">
+                        {tierName && (
+                            <Badge className="bg-indigo-500/20 text-indigo-400 border-indigo-500/30 hover:bg-indigo-500/30">
+                                {tierName}
+                            </Badge>
+                        )}
+                        {planName && (
+                            <Badge variant="outline" className="border-purple-500/30 text-purple-400">
+                                {planName} Plan
+                            </Badge>
+                        )}
+                    </div>
+                </div>
+
+                {/* Model Usage */}
+                <div>
+                    <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 flex items-center gap-1.5">
+                        <User className="h-3 w-3" /> Model Usage
+                    </h3>
+                    <div className="space-y-2">
+                        {models.map((model, i) => {
+                            const pct = Math.round(model.quota * 100);
+                            return (
+                                <div key={i} className="px-4 py-3 rounded-lg border border-border/40 bg-muted/10">
+                                    <div className="flex items-center justify-between mb-2">
+                                        <div className="flex items-center gap-2 min-w-0">
+                                            <span className="text-xs font-medium truncate">{model.label}</span>
+                                            {model.isRecommended && (
+                                                <Badge variant="outline" className="text-[9px] h-4 px-1.5 border-amber-500/30 text-amber-500 shrink-0">★</Badge>
+                                            )}
+                                        </div>
+                                        <span className={cn(
+                                            "text-xs font-semibold tabular-nums shrink-0",
+                                            pct > 50 ? "text-emerald-400" :
+                                                pct > 20 ? "text-amber-400" : "text-red-400"
+                                        )}>
+                                            {pct}%
+                                        </span>
+                                    </div>
+                                    <div className="h-1.5 bg-muted/30 rounded-full overflow-hidden">
+                                        <div
+                                            className={cn(
+                                                "h-full rounded-full transition-all duration-500",
+                                                pct > 50 ? "bg-emerald-500/70" :
+                                                    pct > 20 ? "bg-amber-500/70" : "bg-red-500/70"
+                                            )}
+                                            style={{ width: `${pct}%` }}
+                                        />
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                {/* Reset Timing */}
+                <div className="rounded-xl border border-border/50 bg-muted/10 p-4">
+                    <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                            <div className="w-8 h-8 rounded-lg bg-amber-500/10 flex items-center justify-center">
+                                <Calendar className="h-4 w-4 text-amber-400" />
+                            </div>
+                            <div>
+                                <div className="text-xs font-medium">Credits Reset</div>
+                                <div className="text-[10px] text-muted-foreground">{resetDateStr}</div>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-1.5 text-right">
+                            <Clock className="h-3 w-3 text-muted-foreground" />
+                            <span className="text-sm font-semibold text-amber-400">{countdown}</span>
                         </div>
                     </div>
                 </div>
 
-                {/* Credits */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <CreditCard label="Prompt Credits" icon={<MessageSquare className="h-4 w-4" />}
-                        used={maxPromptCredits - promptCredits} available={promptCredits}
-                        total={maxPromptCredits} pct={promptPct} />
-                    <CreditCard label="Flow Credits" icon={<RefreshCcw className="h-4 w-4" />}
-                        used={maxFlowCredits - flowCredits} available={flowCredits}
-                        total={maxFlowCredits} pct={flowPct} />
-                </div>
-
-                {/* Plan Features */}
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                    <FeatureBadge label="Web Search" enabled={!!planInfo.cascadeWebSearchEnabled} />
-                    <FeatureBadge label="Browser" enabled={!!planInfo.browserEnabled} />
-                    <FeatureBadge label="Buy More Credits" enabled={!!planInfo.canBuyMoreCredits} />
-                    <FeatureBadge label="Teams Tier" value={planInfo.teamsTier?.replace('TEAMS_TIER_', '') || 'N/A'} />
-                </div>
-
-                {/* Models */}
-                <div>
-                    <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3">
-                        Available Models ({models.length})
-                    </h3>
-                    <div className="space-y-2">
-                        {models.map((model, i) => (
-                            <div key={i} className={cn(
-                                "flex items-center gap-3 px-4 py-3 rounded-lg border transition-colors",
-                                model.modelId === defaultModel
-                                    ? "bg-primary/5 border-primary/20"
-                                    : "bg-muted/10 border-border/40"
-                            )}>
-                                <div className="flex-1 min-w-0">
-                                    <div className="flex items-center gap-2">
-                                        <span className="text-xs font-medium">{model.label}</span>
-                                        {model.modelId === defaultModel && (
-                                            <Badge variant="secondary" className="text-[9px] h-4 px-1.5">API Default</Badge>
-                                        )}
-                                        {model.isRecommended && (
-                                            <Badge variant="outline" className="text-[9px] h-4 px-1.5 border-amber-500/30 text-amber-500">Recommended</Badge>
-                                        )}
-                                    </div>
-                                    <div className="text-[10px] text-muted-foreground/50 font-mono mt-0.5">{model.modelId}</div>
-                                </div>
-                                <div className="flex items-center gap-2 shrink-0">
-                                    {model.supportsImages && (
-                                        <Badge variant="secondary" className="h-4 px-1.5 text-[9px] gap-0.5">
-                                            <ImageIcon className="h-2.5 w-2.5" />
-                                        </Badge>
-                                    )}
-                                    <div className={cn(
-                                        "text-xs font-semibold",
-                                        model.quota > 0.5 ? "text-green-400" :
-                                            model.quota > 0.2 ? "text-amber-400" : "text-red-400"
-                                    )}>
-                                        {Math.round(model.quota * 100)}%
-                                    </div>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-
-                {/* Raw data */}
-                <div className="space-y-2">
-                    <CollapsibleSection title="Raw User API Response">
-                        <pre className="p-3 rounded-lg bg-muted/10 border border-border/30 text-[10px] font-mono text-muted-foreground overflow-x-auto whitespace-pre-wrap break-all">
-                            {JSON.stringify(rawUserData, null, 2)}
-                        </pre>
-                    </CollapsibleSection>
-                    <CollapsibleSection title="Raw Profile API Response">
-                        <pre className="p-3 rounded-lg bg-muted/10 border border-border/30 text-[10px] font-mono text-muted-foreground overflow-x-auto whitespace-pre-wrap break-all">
-                            {JSON.stringify(user, null, 2)}
-                        </pre>
-                    </CollapsibleSection>
-                </div>
             </div>
         </div>
     );
 }
 
-// --- Sub-components (Extracted to components/profile/) ---

--- a/src/routes.js
+++ b/src/routes.js
@@ -774,6 +774,7 @@ function setupRoutes(app) {
                 supportsImages: !!m.supportsImages,
                 isRecommended: !!m.isRecommended,
                 quota: m.quotaInfo?.remainingFraction ?? 1,
+                resetTime: m.quotaInfo?.resetTime || null,
             }));
             const defaultModel = data.defaultOverrideModelConfig?.modelOrAlias?.model || '';
             res.json({ models, defaultModel });


### PR DESCRIPTION
Rewrote AccountInfoView to focus on essential subscription info:

- Subscription card: user profile, tier badge, plan name
- Per-model usage: quota bars with % remaining for each AI model
- Real reset timing: uses quotaInfo.resetTime from LS API instead of hardcoded monthly cycle (correctly reflects Ultra 5h reset window)

Removed:
- Prompt Credits / Flow Credits cards
- Plan Features badges grid (Web Search, Browser, etc.)
- Available Models detailed list with modelId
- Raw JSON API dump sections (CollapsibleSection)
- Unused imports: ImageIcon, FeatureBadge, CollapsibleSection, CreditCard

Backend: forward resetTime from quotaInfo in GET /api/models response

Files changed:
  - frontend/components/user-profile.tsx (rewrite AccountInfoView)
  - src/routes.js (add resetTime to /api/models)