### PR TITLE
fix: loading state profile button + LS detection separation

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -41,7 +41,7 @@ function getStoredValue<T>(key: string, fallback: T): T {
 }
 
 export default function Home() {
-  const { connected, steps, conversations, currentConvId, cascadeStatus, conversationsVersion, stepContentVersion, selectConversation, lastUpdate } = useWebSocket();
+  const { connected, detected, steps, conversations, currentConvId, cascadeStatus, conversationsVersion, stepContentVersion, selectConversation, lastUpdate } = useWebSocket();
 
   const [showAnalytics, setShowAnalytics] = useState(() => getStoredValue('antigravity-show-analytics', false));
   const [showTimeline, setShowTimeline] = useState(() => {
@@ -346,9 +346,10 @@ export default function Home() {
   const currentConvInfo = currentConvId ? conversations[currentConvId] : null;
 
   // === Determine what to show in main panel ===
-  const showChat = currentConvId !== null || newChatMode;
-  const showConversationList = !showChat && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl && activeWorkspace !== null;
-  const showWelcome = !showChat && !showConversationList && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl;
+  // When LS not detected, force welcome/detection screen regardless of stored state
+  const showChat = detected && (currentConvId !== null || newChatMode);
+  const showConversationList = detected && !showChat && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl && activeWorkspace !== null;
+  const showWelcome = !detected || (!showChat && !showConversationList && !showAccountInfo && !showSettings && !showLogs && !showBridge && !showSourceControl);
 
   return (
     <AuthGate>
@@ -357,6 +358,7 @@ export default function Home() {
         <AppSidebar
           currentConvId={currentConvId}
           conversationsVersion={conversationsVersion}
+          detected={detected}
           activeWorkspace={activeWorkspace}
           onSelectWorkspace={handleSelectWorkspace}
           onSelectConversation={handleSelectConversation}
@@ -408,10 +410,18 @@ export default function Home() {
               )}
               {showChat && <span className="text-xs text-muted-foreground font-mono hidden md:inline">{steps.length > 0 ? `${steps.length} steps` : ''}</span>}
               {lastUpdate && <span className="text-xs text-muted-foreground hidden md:inline">{lastUpdate}</span>}
-              {/* Connected indicator pill — visible on all screen sizes */}
-              <div className={`flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium ${connected ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' : 'bg-red-500/10 text-red-400 border border-red-500/20'}`}>
-                <div className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-emerald-400 animate-pulse' : 'bg-red-400'}`} />
-                <span>{connected ? 'Connected' : 'Detecting...'}</span>
+              {/* Status indicators — WS connection + LS detection */}
+              <div className="flex items-center gap-1.5">
+                {/* WebSocket connection status */}
+                <div className={`flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium ${connected ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' : 'bg-red-500/10 text-red-400 border border-red-500/20'}`}>
+                  <div className={`w-1.5 h-1.5 rounded-full ${connected ? 'bg-emerald-400' : 'bg-red-400'}`} />
+                  <span>WS</span>
+                </div>
+                {/* Language Server detection status */}
+                <div className={`flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium ${detected ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20' : connected ? 'bg-amber-500/10 text-amber-400 border border-amber-500/20' : 'bg-muted text-muted-foreground border border-border/30'}`}>
+                  <div className={`w-1.5 h-1.5 rounded-full ${detected ? 'bg-emerald-400' : connected ? 'bg-amber-400 animate-pulse' : 'bg-muted-foreground/50'}`} />
+                  <span>{detected ? 'LS Connected' : connected ? 'Detecting...' : 'LS N/A'}</span>
+                </div>
               </div>
             </div>
 
@@ -460,7 +470,7 @@ export default function Home() {
           )}
 
           {/* === Main panel content === */}
-          {showWelcome && !connected && (
+          {showWelcome && !detected && (
             <div className="flex-1 flex items-center justify-center">
               <div className="text-center space-y-5 max-w-sm">
                 <div className="flex items-center justify-center gap-3">
@@ -492,7 +502,7 @@ export default function Home() {
             </div>
           )}
 
-          {showWelcome && connected && !activeWorkspace && (
+          {showWelcome && detected && !activeWorkspace && (
             <div className="flex-1 flex items-center justify-center">
               <div className="text-center space-y-4">
                 <div className="flex items-center justify-center gap-3">
@@ -506,17 +516,17 @@ export default function Home() {
             </div>
           )}
 
-          {showAccountInfo && <AccountInfoView />}
+          {detected && showAccountInfo && <AccountInfoView />}
 
-          {showSettings && <SettingsView />}
+          {detected && showSettings && <SettingsView />}
 
           {/* Always mounted — WS stays alive, events accumulate in background */}
-          <div className={showLogs ? 'flex flex-col flex-1 min-h-0 overflow-hidden' : 'hidden'}>
+          <div className={detected && showLogs ? 'flex flex-col flex-1 min-h-0 overflow-hidden' : 'hidden'}>
             <AgentLogsView />
           </div>
 
           {/* Agent Bridge panel */}
-          <div className={showBridge ? 'flex flex-col flex-1 min-h-0 overflow-hidden' : 'hidden'}>
+          <div className={detected && showBridge ? 'flex flex-col flex-1 min-h-0 overflow-hidden' : 'hidden'}>
             <AgentBridgeView />
           </div>
 

--- a/frontend/components/agent-logs-view.tsx
+++ b/frontend/components/agent-logs-view.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, memo } from 'react';
 import { cn } from '@/lib/utils';
-import { getWsUrl } from '@/lib/config';
-import { authWsUrl } from '@/lib/auth';
+import { wsService } from '@/lib/ws-service';
 import {
     Activity, User, Bot, Wrench, Filter, Trash2,
     Wifi, WifiOff, ChevronDown, ChevronRight,
@@ -261,8 +260,6 @@ export function AgentLogsView() {
     const [wsStatus, setWsStatus] = useState<'connecting' | 'connected' | 'disconnected'>('connecting');
     const [autoScroll, setAutoScroll] = useState(true);
     const bottomRef = useRef<HTMLDivElement>(null);
-    const wsRef = useRef<WebSocket | null>(null);
-    const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const eventIdRef = useRef(0);
 
     const addEvent = useCallback((evt: Omit<LogEvent, 'id' | 'ts'>) => {
@@ -273,83 +270,66 @@ export function AgentLogsView() {
         });
     }, []);
 
-    const connect = useCallback(async () => {
-        setWsStatus('connecting');
-        try {
-            const wsBase = await getWsUrl();
-            const ws = new WebSocket(authWsUrl(wsBase));
-            wsRef.current = ws;
-
-            ws.onopen = () => {
-                setWsStatus('connected');
-                // Subscribe to ALL events regardless of conversation (Live Logs mode)
-                ws.send(JSON.stringify({ type: 'subscribe_all' }));
-            };
-
-            ws.onmessage = (evt) => {
-                try {
-                    const data = JSON.parse(evt.data);
-                    const convId = data.conversationId || data.cascadeId || '';
-
-                    if (data.type === 'cascade_status') {
-                        addEvent({ type: 'cascade_status', convId, payload: data });
-                    } else if (data.type === 'conversations_updated') {
-                        addEvent({ type: 'conversations_updated', convId: '', payload: data });
-                    } else if (data.type === 'steps_new') {
-                        const steps: any[] = data.steps || [];
-                        const startIdx = (data.total || steps.length) - steps.length;
-                        steps.forEach((step, i) => {
-                            const stepType = step.type || '';
-                            const role = getStepRole(stepType);
-                            addEvent({
-                                type: 'step',
-                                convId,
-                                stepRole: role,
-                                stepLabel: STEP_LABELS[stepType] || stepType.replace('CORTEX_STEP_TYPE_', ''),
-                                stepContent: extractContent(step, stepType),
-                                stepIndex: startIdx + i,
-                                payload: { step },
-                            });
-                        });
-                    } else if (data.type === 'step_updated') {
-                        const step = data.step || {};
-                        const stepType = step.type || '';
-                        const role = getStepRole(stepType);
-                        // Only log meaningful updates (content changes), not every poll tick
-                        const content = extractContent(step, stepType);
-                        if (content) {
-                            addEvent({
-                                type: 'step_update',
-                                convId,
-                                stepRole: role,
-                                stepLabel: `↻ ${STEP_LABELS[stepType] || stepType.replace('CORTEX_STEP_TYPE_', '')}`,
-                                stepContent: content,
-                                stepIndex: data.index,
-                                payload: { step, index: data.index },
-                            });
-                        }
-                    }
-                } catch { }
-            };
-
-            ws.onclose = () => {
-                setWsStatus('disconnected');
-                reconnectRef.current = setTimeout(connect, 3000);
-            };
-            ws.onerror = () => ws.close();
-        } catch {
-            setWsStatus('disconnected');
-            reconnectRef.current = setTimeout(connect, 3000);
-        }
-    }, [addEvent]);
-
+    // Subscribe to shared WS service for all messages (Live Logs mode)
     useEffect(() => {
-        connect();
+        if (!wsService) return;
+
+        // Track connection status via shared service events
+        const offOpen = wsService.on('__ws_open', () => setWsStatus('connected'));
+        const offClose = wsService.on('__ws_close', () => setWsStatus('disconnected'));
+        // Set initial status
+        setWsStatus(wsService.connected ? 'connected' : 'connecting');
+
+        // Listen to ALL messages for live logging
+        const offAll = wsService.onAll((data) => {
+            const convId = (data.conversationId as string) || (data.cascadeId as string) || '';
+
+            if (data.type === 'cascade_status') {
+                addEvent({ type: 'cascade_status', convId, payload: data });
+            } else if (data.type === 'conversations_updated') {
+                addEvent({ type: 'conversations_updated', convId: '', payload: data });
+            } else if (data.type === 'steps_new') {
+                const steps: any[] = (data.steps as any[]) || [];
+                const startIdx = ((data.total as number) || steps.length) - steps.length;
+                steps.forEach((step, i) => {
+                    const stepType = step.type || '';
+                    const role = getStepRole(stepType);
+                    addEvent({
+                        type: 'step',
+                        convId,
+                        stepRole: role,
+                        stepLabel: STEP_LABELS[stepType] || stepType.replace('CORTEX_STEP_TYPE_', ''),
+                        stepContent: extractContent(step, stepType),
+                        stepIndex: startIdx + i,
+                        payload: { step },
+                    });
+                });
+            } else if (data.type === 'step_updated') {
+                const step = (data.step as any) || {};
+                const stepType = step.type || '';
+                const role = getStepRole(stepType);
+                // Only log meaningful updates (content changes), not every poll tick
+                const content = extractContent(step, stepType);
+                if (content) {
+                    addEvent({
+                        type: 'step_update',
+                        convId,
+                        stepRole: role,
+                        stepLabel: `↻ ${STEP_LABELS[stepType] || stepType.replace('CORTEX_STEP_TYPE_', '')}`,
+                        stepContent: content,
+                        stepIndex: data.index as number,
+                        payload: { step, index: data.index },
+                    });
+                }
+            }
+        });
+
         return () => {
-            if (reconnectRef.current) clearTimeout(reconnectRef.current);
-            wsRef.current?.close();
+            offOpen();
+            offClose();
+            offAll();
         };
-    }, [connect]);
+    }, [addEvent]);
 
     // Auto-scroll to bottom
     useEffect(() => {

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -51,6 +51,8 @@ import type { ConvSummary, WorkspaceData } from "./sidebar/workspace-group"
 interface AppSidebarProps {
     currentConvId: string | null
     conversationsVersion: number
+    /** Whether Windsurf Language Server is detected by backend */
+    detected: boolean
     onSelectConversation: (convId: string | null, wsName: string) => void
     onSelectWorkspace: (wsName: string) => void
     onShowAccountInfo: () => void
@@ -67,6 +69,7 @@ interface AppSidebarProps {
 export function AppSidebar({
     currentConvId,
     conversationsVersion,
+    detected,
     onSelectConversation,
     onSelectWorkspace,
     onShowAccountInfo,
@@ -111,8 +114,12 @@ export function AppSidebar({
         return ""
     }, [newWsName, wsData, folders])
 
-    // Fetch user profile once on mount
+    // Fetch user profile on mount and when connection is established
     useEffect(() => {
+        if (!detected) {
+            setUserProfile(null)
+            return
+        }
         fetch(`${API_BASE}/api/user/profile`, { headers: authHeaders() })
             .then(r => r.json())
             .then(d => {
@@ -125,7 +132,7 @@ export function AppSidebar({
                 })
             })
             .catch(() => { })
-    }, [])
+    }, [detected])
 
     const loadAll = useCallback(async () => {
         try {
@@ -190,26 +197,33 @@ export function AppSidebar({
         if (wsVersion && wsVersion > 0) loadAll()
     }, [wsVersion, loadAll])
 
+    // Refresh workspace list when backend broadcasts conversations_updated or status change via WS
     useEffect(() => {
-        let interval: ReturnType<typeof setInterval> | null = null
-        const start = () => {
-            if (!interval) interval = setInterval(loadAll, 30000)
-        }
-        const stop = () => {
-            if (interval) {
-                clearInterval(interval)
-                interval = null
-            }
-        }
-        const onVisibility = () => (document.hidden ? stop() : start())
+        if (conversationsVersion > 0) loadAll()
+    }, [conversationsVersion, loadAll])
 
-        start()
-        document.addEventListener("visibilitychange", onVisibility)
-        return () => {
-            stop()
-            document.removeEventListener("visibilitychange", onVisibility)
-        }
-    }, [loadAll])
+    // TODO: Temporarily disabled 30s polling — workspace updates now driven by WS events
+    // (conversationsVersion from useWebSocket). Re-enable if WS proves unreliable.
+    // useEffect(() => {
+    //     let interval: ReturnType<typeof setInterval> | null = null
+    //     const start = () => {
+    //         if (!interval) interval = setInterval(loadAll, 30000)
+    //     }
+    //     const stop = () => {
+    //         if (interval) {
+    //             clearInterval(interval)
+    //             interval = null
+    //         }
+    //     }
+    //     const onVisibility = () => (document.hidden ? stop() : start())
+    //
+    //     start()
+    //     document.addEventListener("visibilitychange", onVisibility)
+    //     return () => {
+    //         stop()
+    //         document.removeEventListener("visibilitychange", onVisibility)
+    //     }
+    // }, [loadAll])
 
     const handleWorkspaceClick = useCallback(
         (arrayIdx: number) => {
@@ -401,13 +415,20 @@ export function AppSidebar({
                                             {userProfile?.avatar && (
                                                 <AvatarImage src={`data:image/png;base64,${userProfile.avatar}`} alt={userProfile.name} />
                                             )}
-                                            <AvatarFallback className="rounded-lg bg-indigo-500/20 text-indigo-400 text-xs font-semibold">
-                                                {userProfile?.name?.[0]?.toUpperCase() ?? '?'}
+                                            <AvatarFallback className={cn(
+                                                "rounded-lg text-xs font-semibold",
+                                                detected ? "bg-indigo-500/20 text-indigo-400" : "bg-muted text-muted-foreground"
+                                            )}>
+                                                {userProfile?.name?.[0]?.toUpperCase() ?? (detected ? '?' : '—')}
                                             </AvatarFallback>
                                         </Avatar>
                                         <div className="grid flex-1 text-left text-sm leading-tight">
-                                            <span className="truncate font-medium text-xs">{userProfile?.name ?? 'Loading...'}</span>
-                                            <span className="truncate text-[10px] text-sidebar-foreground/60">{userProfile?.tier ?? ''}</span>
+                                            <span className="truncate font-medium text-xs">
+                                                {userProfile?.name ?? (detected ? 'Loading...' : 'Not Connected')}
+                                            </span>
+                                            <span className="truncate text-[10px] text-sidebar-foreground/60">
+                                                {userProfile?.tier ?? (detected ? '' : 'Open Antigravity IDE')}
+                                            </span>
                                         </div>
                                         <EllipsisVertical className="ml-auto size-4" />
                                     </SidebarMenuButton>

--- a/frontend/lib/websocket.ts
+++ b/frontend/lib/websocket.ts
@@ -4,12 +4,14 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { Step, ConversationsResponse, TrajectorySummary } from './types';
 import { extractStepContent } from './step-utils';
 import { showNotification } from './notifications';
-import { API_BASE, getWsUrl } from './config';
-import { authHeaders, authWsUrl } from './auth';
+import { API_BASE } from './config';
+import { authHeaders } from './auth';
 import { getCascadeStatus } from './cascade-api';
+import { wsService } from './ws-service';
 
 interface WSState {
-    connected: boolean;
+    connected: boolean;  // WebSocket connection to backend
+    detected: boolean;   // Windsurf Language Server detected by backend
     steps: Step[];
     conversations: Record<string, TrajectorySummary>;
     currentConvId: string | null;
@@ -27,6 +29,7 @@ export function useWebSocket() {
 
     const [state, setState] = useState<WSState>({
         connected: false,
+        detected: false,
         steps: [] as Step[],
         conversations: {} as Record<string, TrajectorySummary>,
         currentConvId: storedConvId,
@@ -35,8 +38,6 @@ export function useWebSocket() {
         conversationsVersion: 0,
         stepContentVersion: 0,
     });
-    const wsRef = useRef<WebSocket | null>(null);
-    const reconnectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     // Use refs for values needed in WS handlers to avoid stale closures
     const currentConvIdRef = useRef<string | null>(storedConvId);
 
@@ -55,144 +56,150 @@ export function useWebSocket() {
         }
     }, []);
 
-    // Stable ref for loadConversations so connect doesn't depend on it
+    // Stable ref for loadConversations so handlers don't depend on it
     const loadConversationsRef = useRef(loadConversations);
     loadConversationsRef.current = loadConversations;
 
-    const connect = useCallback(async () => {
-        try {
-            const wsBase = await getWsUrl();
-            const ws = new WebSocket(authWsUrl(wsBase));
-            wsRef.current = ws;
+    useEffect(() => {
+        if (!wsService) return;
 
-            ws.onopen = () => {
-                console.log('[WS] connected, re-syncing conversation...');
-                // Use ref for immediate access to current conv ID (no stale closure)
-                const convId = currentConvIdRef.current;
-                console.log('[WS] onopen currentConvId:', convId?.substring(0, 8));
-                if (convId && ws.readyState === 1) {
-                    ws.send(JSON.stringify({ type: 'set_conversation', conversationId: convId }));
-                }
-            };
+        // Connect shared WS service (idempotent — safe if already connected)
+        wsService.connect();
 
-            ws.onmessage = (event) => {
-                try {
-                    const data = JSON.parse(event.data);
-                    if (data.type === 'status') {
-                        console.log('[WS] status:', data.detected);
-                        setState(prev => ({ ...prev, connected: data.detected }));
-                        if (data.detected) loadConversationsRef.current();
-                    } else if (data.type === 'steps_init') {
-                        console.log('[WS] steps_init:', data.steps?.length, 'for', data.conversationId?.substring(0, 8));
-                        setState(prev => {
-                            // Only accept init for current conversation
-                            if (data.conversationId && data.conversationId !== prev.currentConvId) return prev;
-                            return {
-                                ...prev,
-                                steps: data.steps || [],
-                                lastUpdate: new Date().toLocaleTimeString(),
-                            };
-                        });
-                        // Fetch cascade status on init (handles reload/reconnect)
-                        const convId = data.conversationId || currentConvIdRef.current;
-                        if (convId) {
-                            getCascadeStatus(convId)
-                                .then(s => {
-                                    setState(prev => {
-                                        if (prev.currentConvId !== convId) return prev;
-                                        return { ...prev, cascadeStatus: s.status || null };
-                                    });
-                                })
-                                .catch(() => { /* ignore — status unavailable */ });
-                        }
-                    } else if (data.type === 'steps_new') {
-                        console.log('[WS] steps_new received:', data.steps?.length, 'for', data.conversationId?.substring(0, 8));
-                        setState(prev => {
-                            // Only append if same conversation
-                            if (data.conversationId && data.conversationId !== prev.currentConvId) {
-                                console.log('[WS] steps_new SKIP: conv mismatch', data.conversationId?.substring(0, 8), '!=', prev.currentConvId?.substring(0, 8));
-                                return prev;
-                            }
-                            const newSteps = data.steps || [];
-                            if (newSteps.length === 0) return prev;
-                            // Dedup: only append steps beyond current length
-                            const currentLen = prev.steps.length;
-                            const expectedStart = data.total ? data.total - newSteps.length : currentLen;
-                            const skipCount = Math.max(0, currentLen - expectedStart);
-                            const actualNew = newSteps.slice(skipCount);
-                            console.log(`[WS] steps_new: ${newSteps.length} incoming, currentLen=${currentLen}, total=${data.total}, expectedStart=${expectedStart}, skipCount=${skipCount}, actualNew=${actualNew.length}`);
-                            if (actualNew.length === 0) return prev;
-                            return {
-                                ...prev,
-                                steps: [...prev.steps, ...actualNew],
-                                lastUpdate: new Date().toLocaleTimeString(),
-                            };
-                        });
-                        // Desktop notification for agent responses when tab hidden
-                        const notifySteps = (data.steps || []).filter((s: Step) => s.type === 'CORTEX_STEP_TYPE_NOTIFY_USER');
-                        if (notifySteps.length > 0) {
-                            const content = extractStepContent(notifySteps[0]) || 'Agent needs your attention';
-                            showNotification('AntigravityChat', content);
-                        }
-                    } else if (data.type === 'step_updated') {
-                        setState(prev => {
-                            if (data.conversationId && data.conversationId !== prev.currentConvId) return prev;
-                            const updated = [...prev.steps];
-                            if (data.index >= 0 && data.index < updated.length) {
-                                updated[data.index] = data.step;
-                            }
-                            return { ...prev, steps: updated, lastUpdate: new Date().toLocaleTimeString(), stepContentVersion: prev.stepContentVersion + 1 };
-                        });
-                    } else if (data.type === 'cascade_status') {
-                        setState(prev => {
-                            if (data.conversationId && data.conversationId !== prev.currentConvId) return prev;
-                            return { ...prev, cascadeStatus: data.status };
-                        });
-                    } else if (data.type === 'conversations_updated') {
-                        // Backend discovered new conversations — bump version to trigger sidebar refresh
-                        console.log('[WS] conversations_updated — refreshing sidebar');
-                        setState(prev => ({ ...prev, conversationsVersion: prev.conversationsVersion + 1 }));
-                    }
-                } catch (e) {
-                    console.error('WS parse error:', e);
-                }
-            };
-
-            ws.onclose = () => {
-                setState(prev => ({ ...prev, connected: false }));
-                reconnectRef.current = setTimeout(connect, 2000);
-            };
-
-            ws.onerror = () => ws.close();
-        } catch {
-            reconnectRef.current = setTimeout(connect, 2000);
+        // Sync initial state if WS already connected (handles HMR/StrictMode remount)
+        if (wsService.connected) {
+            setState(prev => ({ ...prev, connected: true }));
+            const convId = currentConvIdRef.current;
+            if (convId) {
+                wsService.send({ type: 'set_conversation', conversationId: convId });
+            }
         }
-    }, []); // No dependencies — fully stable function
+
+        // Re-sync conversation on WS open
+        const offOpen = wsService.on('__ws_open', () => {
+            console.log('[WS] connected, re-syncing conversation...');
+            setState(prev => ({ ...prev, connected: true }));
+            const convId = currentConvIdRef.current;
+            console.log('[WS] onopen currentConvId:', convId?.substring(0, 8));
+            if (convId) {
+                wsService!.send({ type: 'set_conversation', conversationId: convId });
+            }
+        });
+
+        const offClose = wsService.on('__ws_close', () => {
+            setState(prev => ({ ...prev, connected: false, detected: false }));
+        });
+
+        const offStatus = wsService.on('status', (data) => {
+            console.log('[WS] status:', data.detected);
+            setState(prev => ({ ...prev, detected: !!data.detected }));
+            if (data.detected) loadConversationsRef.current();
+        });
+
+        const offStepsInit = wsService.on('steps_init', (data) => {
+            console.log('[WS] steps_init:', (data.steps as Step[])?.length, 'for', (data.conversationId as string)?.substring(0, 8));
+            setState(prev => {
+                if (data.conversationId && data.conversationId !== prev.currentConvId) return prev;
+                return {
+                    ...prev,
+                    steps: (data.steps as Step[]) || [],
+                    lastUpdate: new Date().toLocaleTimeString(),
+                };
+            });
+            // Fetch cascade status on init (handles reload/reconnect)
+            const convId = (data.conversationId as string) || currentConvIdRef.current;
+            if (convId) {
+                getCascadeStatus(convId)
+                    .then(s => {
+                        setState(prev => {
+                            if (prev.currentConvId !== convId) return prev;
+                            return { ...prev, cascadeStatus: s.status || null };
+                        });
+                    })
+                    .catch(() => { /* ignore — status unavailable */ });
+            }
+        });
+
+        const offStepsNew = wsService.on('steps_new', (data) => {
+            console.log('[WS] steps_new received:', (data.steps as Step[])?.length, 'for', (data.conversationId as string)?.substring(0, 8));
+            setState(prev => {
+                if (data.conversationId && data.conversationId !== prev.currentConvId) {
+                    console.log('[WS] steps_new SKIP: conv mismatch', (data.conversationId as string)?.substring(0, 8), '!=', prev.currentConvId?.substring(0, 8));
+                    return prev;
+                }
+                const newSteps = (data.steps as Step[]) || [];
+                if (newSteps.length === 0) return prev;
+                const currentLen = prev.steps.length;
+                const expectedStart = data.total ? (data.total as number) - newSteps.length : currentLen;
+                const skipCount = Math.max(0, currentLen - expectedStart);
+                const actualNew = newSteps.slice(skipCount);
+                console.log(`[WS] steps_new: ${newSteps.length} incoming, currentLen=${currentLen}, total=${data.total}, expectedStart=${expectedStart}, skipCount=${skipCount}, actualNew=${actualNew.length}`);
+                if (actualNew.length === 0) return prev;
+                return {
+                    ...prev,
+                    steps: [...prev.steps, ...actualNew],
+                    lastUpdate: new Date().toLocaleTimeString(),
+                };
+            });
+            // Desktop notification for agent responses when tab hidden
+            const notifySteps = ((data.steps as Step[]) || []).filter((s: Step) => s.type === 'CORTEX_STEP_TYPE_NOTIFY_USER');
+            if (notifySteps.length > 0) {
+                const content = extractStepContent(notifySteps[0]) || 'Agent needs your attention';
+                showNotification('AntigravityChat', content);
+            }
+        });
+
+        const offStepUpdated = wsService.on('step_updated', (data) => {
+            setState(prev => {
+                if (data.conversationId && data.conversationId !== prev.currentConvId) return prev;
+                const updated = [...prev.steps];
+                const index = data.index as number;
+                if (index >= 0 && index < updated.length) {
+                    updated[index] = data.step as Step;
+                }
+                return { ...prev, steps: updated, lastUpdate: new Date().toLocaleTimeString(), stepContentVersion: prev.stepContentVersion + 1 };
+            });
+        });
+
+        const offCascadeStatus = wsService.on('cascade_status', (data) => {
+            setState(prev => {
+                if (data.conversationId && data.conversationId !== prev.currentConvId) return prev;
+                return { ...prev, cascadeStatus: data.status as string };
+            });
+        });
+
+        const offConvUpdated = wsService.on('conversations_updated', () => {
+            console.log('[WS] conversations_updated — refreshing sidebar');
+            setState(prev => ({ ...prev, conversationsVersion: prev.conversationsVersion + 1 }));
+        });
+
+        return () => {
+            offOpen();
+            offClose();
+            offStatus();
+            offStepsInit();
+            offStepsNew();
+            offStepUpdated();
+            offCascadeStatus();
+            offConvUpdated();
+        };
+    }, []);
 
     const selectConversation = useCallback((id: string | null) => {
         currentConvIdRef.current = id; // update ref immediately for WS handlers
         setState(prev => ({ ...prev, currentConvId: id, steps: [], cascadeStatus: null }));
-        if (id && wsRef.current?.readyState === 1) {
-            wsRef.current.send(JSON.stringify({ type: 'set_conversation', conversationId: id }));
+        if (id && wsService) {
+            wsService.send({ type: 'set_conversation', conversationId: id });
         }
     }, []);
-
-    useEffect(() => {
-        connect();
-        return () => {
-            if (reconnectRef.current) clearTimeout(reconnectRef.current);
-            wsRef.current?.close();
-        };
-    }, [connect]);
 
     // Fallback safety net: re-sync only for rare missed WS broadcasts
     // Primary data flow is BE push (cascade_status + steps_new), not this timer
     useEffect(() => {
         const fallback = setInterval(() => {
             const convId = currentConvIdRef.current;
-            const ws = wsRef.current;
-            if (convId && ws?.readyState === 1) {
-                ws.send(JSON.stringify({ type: 'set_conversation', conversationId: convId }));
+            if (convId && wsService?.connected) {
+                wsService.send({ type: 'set_conversation', conversationId: convId });
             }
         }, 30000); // 30s — safety net only, not primary data flow
         return () => clearInterval(fallback);

--- a/frontend/lib/ws-service.ts
+++ b/frontend/lib/ws-service.ts
@@ -1,0 +1,103 @@
+/**
+ * Singleton WebSocket service — one shared connection for the entire app.
+ * Components subscribe to message types via addEventListener pattern.
+ * Handles connect, reconnect, auth, and exposes send().
+ */
+'use client';
+
+import { getWsUrl } from './config';
+import { authWsUrl } from './auth';
+
+type WSListener = (data: Record<string, unknown>) => void;
+
+class WebSocketService {
+    private ws: WebSocket | null = null;
+    private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    private listeners = new Map<string, Set<WSListener>>(); // type → listeners
+    private wildcardListeners = new Set<WSListener>(); // receive ALL messages
+    private _connected = false;
+
+    get connected() { return this._connected; }
+
+    /** Subscribe to a specific message type (e.g. 'status', 'steps_new') */
+    on(type: string, fn: WSListener) {
+        if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+        this.listeners.get(type)!.add(fn);
+        return () => { this.listeners.get(type)?.delete(fn); };
+    }
+
+    /** Subscribe to ALL messages (for Live Logs) */
+    onAll(fn: WSListener) {
+        this.wildcardListeners.add(fn);
+        return () => { this.wildcardListeners.delete(fn); };
+    }
+
+    /** Send a message to the backend */
+    send(data: Record<string, unknown>) {
+        if (this.ws?.readyState === WebSocket.OPEN) {
+            this.ws.send(JSON.stringify(data));
+        }
+    }
+
+    /** Connect (idempotent — safe to call multiple times) */
+    async connect() {
+        if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+            return; // already connected or connecting
+        }
+        try {
+            const wsBase = await getWsUrl();
+            const ws = new WebSocket(authWsUrl(wsBase));
+            this.ws = ws;
+
+            ws.onopen = () => {
+                console.log('[WS-Service] connected');
+                this._connected = true;
+                // Subscribe to all events so backend sends messages for ALL conversations
+                // (needed for Live Logs which monitors all cascades)
+                ws.send(JSON.stringify({ type: 'subscribe_all' }));
+                this.emit('__ws_open', {});
+            };
+
+            ws.onmessage = (event) => {
+                try {
+                    const data = JSON.parse(event.data);
+                    const type = data.type as string;
+                    // Emit to type-specific listeners
+                    if (type) {
+                        this.listeners.get(type)?.forEach(fn => fn(data));
+                    }
+                    // Emit to wildcard listeners (Live Logs)
+                    this.wildcardListeners.forEach(fn => fn(data));
+                } catch (e) {
+                    console.error('[WS-Service] parse error:', e);
+                }
+            };
+
+            ws.onclose = () => {
+                console.log('[WS-Service] disconnected');
+                this._connected = false;
+                this.emit('__ws_close', {});
+                this.reconnectTimer = setTimeout(() => this.connect(), 2000);
+            };
+
+            ws.onerror = () => ws.close();
+        } catch {
+            this.reconnectTimer = setTimeout(() => this.connect(), 2000);
+        }
+    }
+
+    /** Disconnect and clean up */
+    disconnect() {
+        if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+        this.ws?.close();
+        this.ws = null;
+        this._connected = false;
+    }
+
+    private emit(type: string, data: Record<string, unknown>) {
+        this.listeners.get(type)?.forEach(fn => fn(data));
+    }
+}
+
+// Singleton instance — shared across entire app
+export const wsService = typeof window !== 'undefined' ? new WebSocketService() : null;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "setup": "npm install && npm install --prefix frontend && node -e \"const fs=require('fs');if(!fs.existsSync('settings.json'))fs.copyFileSync('settings.sample.json','settings.json');console.log('✅ Setup complete! Run: npm run dev')\"",
     "start": "node server.js",
-    "dev": "concurrently -n BE,FE -c cyan,magenta \"node server.js\" \"npm run dev --prefix frontend\"",
-    "server": "node server.js",
+    "dev": "concurrently -n BE,FE -c cyan,magenta \"node --watch server.js\" \"npm run dev --prefix frontend\"",
+    "server": "node --watch server.js",
     "tunnel:be": "cloudflared tunnel --url http://localhost:3500",
     "tunnel:fe": "cloudflared tunnel --url http://localhost:3000",
     "tunnel": "concurrently -n TUN-BE,TUN-FE -c green,yellow \"npm run tunnel:be\" \"npm run tunnel:fe\"",

--- a/src/detector.js
+++ b/src/detector.js
@@ -228,6 +228,12 @@ async function init(onReady) {
 
     // Activate first instance
     switchToInstance(0);
+    lastDetectedState = true;
+    // Broadcast detection status to all connected clients (they may have connected before init finished)
+    try {
+        const { broadcastAll } = require('./ws');
+        broadcastAll({ type: 'status', detected: true, port: lsInstances[0]?.port || null });
+    } catch { }
     if (onReady) onReady();
 }
 
@@ -253,6 +259,7 @@ function switchToInstance(index) {
 // Periodic re-scan for new LS instances (every 10s)
 const RESCAN_INTERVAL = 10000;
 let rescanTimer = null;
+let lastDetectedState = false; // track detection state transitions
 
 function startAutoRescan() {
     if (rescanTimer) clearInterval(rescanTimer);
@@ -336,6 +343,17 @@ async function rescanNow() {
             try {
                 const { broadcastAll } = require('./ws');
                 broadcastAll({ type: 'conversations_updated' });
+            } catch { }
+        }
+
+        // Broadcast detection status when state transitions (detected ↔ not detected)
+        const nowDetected = lsInstances.length > 0;
+        if (nowDetected !== lastDetectedState) {
+            lastDetectedState = nowDetected;
+            try {
+                const { broadcastAll } = require('./ws');
+                broadcastAll({ type: 'status', detected: nowDetected, port: lsInstances[0]?.port || null });
+                console.log(`[WS] status broadcast: detected=${nowDetected}`);
             } catch { }
         }
     } catch { }

--- a/src/routes.js
+++ b/src/routes.js
@@ -271,6 +271,9 @@ function setupRoutes(app) {
         if (!folderPath && name) {
             const settings = getSettings();
             const root = settings.defaultWorkspaceRoot;
+            if (!root) {
+                return res.status(400).json({ error: 'defaultWorkspaceRoot is not configured — set it in Settings first' });
+            }
             // Ensure root exists
             if (!fs.existsSync(root)) {
                 fs.mkdirSync(root, { recursive: true });


### PR DESCRIPTION
## Summary
- **Separate WebSocket connection vs LS detection**: Split `connected` (WS open/close) and `detected` (Windsurf LS found by backend) into distinct states in `useWebSocket()` hook
- **Fix profile button stuck on "Loading..."**: Sidebar profile now reacts to `detected` state — shows "Not Connected / Open Antigravity IDE" when LS not found, auto-fetches profile when detected
- **Fix "Antigravity Not Detected" screen hidden by stale localStorage**: When `!detected`, force welcome/detection screen regardless of persisted panel states (`currentConvId`, `showSettings`, etc.)
- **Shared WebSocket singleton** (`ws-service.ts`): Single WS connection shared across `useWebSocket` and `AgentLogsView`, eliminating duplicate connections
- **Backend broadcasts LS status transitions**: Detector now broadcasts on state changes instead of every poll cycle
- **Header shows separate WS + LS indicators**: Two distinct pills for connection and detection status

## Changes
| File | What |
|---|---|
| `frontend/lib/ws-service.ts` | **New** — WS singleton with event emitter pattern |
| `frontend/lib/websocket.ts` | Refactored to use ws-service, added `detected` state |
| `frontend/components/app-sidebar.tsx` | Profile button reacts to `detected` prop, re-fetches on connect |
| `frontend/app/page.tsx` | Panel visibility gated by `detected`, passes prop to sidebar |
| `frontend/components/agent-logs-view.tsx` | Refactored to use shared ws-service |
| `src/detector.js` | Broadcasts status only on state transitions |
| `src/routes.js` | Sends initial status on WS connect |
| `package.json` | Added `--watch` flag for backend dev hot reload |

## Test plan
- [ ] Start app WITHOUT Antigravity IDE open → should show "Antigravity Not Detected" guide + profile shows "Not Connected"
- [ ] Open Antigravity IDE → within ~10s, profile auto-updates with user name/tier, detection screen disappears
- [ ] Close Antigravity IDE → profile reverts to "Not Connected", detection screen reappears
- [ ] Refresh page with localStorage having stale convId → still shows detection screen when LS not found
- [ ] Verify Agent Logs panel shares same WS connection (no duplicate `subscribe_all` in backend logs)