### PR TITLE
hotfix: fix macOS LS binary path — use language_server_macos_arm inst…

### DIFF
--- a/src/headless-ls.js
+++ b/src/headless-ls.js
@@ -21,7 +21,16 @@ function getLsBinaryPath() {
             'language_server_windows_x64.exe'
         );
     } else if (platform === 'darwin') {
-        return '/Applications/Antigravity.app/Contents/Resources/app/extensions/antigravity/bin/language_server';
+        const base = '/Applications/Antigravity.app/Contents/Resources/app/extensions/antigravity/bin';
+        const candidates = [
+            path.join(base, 'language_server_macos_arm'),
+            path.join(base, 'language_server_macos_x64'),
+            path.join(base, 'language_server'),
+        ];
+        for (const p of candidates) {
+            if (fs.existsSync(p)) return p;
+        }
+        return candidates[0]; // will fail at launch with descriptive error
     } else {
         // Linux — try common paths
         const home = os.homedir();


### PR DESCRIPTION
…ead of language_server

Binary on macOS is named language_server_macos_arm (ARM) or language_server_macos_x64 (Intel), not 'language_server'. Now auto-detects the correct binary with fallback candidates.