### PR TITLE
fix: replace writeFileSync with async debounced atomic flush in config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "tunnel:be": "cloudflared tunnel --url http://localhost:3500",
     "tunnel:fe": "cloudflared tunnel --url http://localhost:3000",
     "tunnel": "concurrently -n TUN-BE,TUN-FE -c green,yellow \"npm run tunnel:be\" \"npm run tunnel:fe\"",
-    "online": "node start-tunnel.js"
+    "online": "node start-tunnel.js",
+    "test": "node --test tests/*.test.js",
+    "test:unit": "node --test tests/config-persistence.test.js",
+    "test:integration": "node --test tests/settings-integration.test.js"
   },
   "dependencies": {
     "discord.js": "^14.25.1",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 // === Shared State & Constants ===
 const os = require('os');
 const fs = require('fs');
+const fsPromises = require('fs/promises');
 const path = require('path');
 
 const lsConfig = { port: null, csrfToken: null, detected: false, useTls: false };
@@ -15,6 +16,117 @@ const BATCH_SIZE = 200;
 const STEP_WINDOW_SIZE = 500;       // max steps to hold in memory per conversation
 const STEP_LOAD_CHUNK = 200;        // how many older steps to load on scroll-up
 
+// --- Async persistence engine ---
+const DEBOUNCE_MS = 750;
+const MAX_FLUSH_RETRIES = 3;
+
+/**
+ * Factory: create an async persist engine for a JSON settings file.
+ * Pattern: sync in-memory update + debounced atomic flush to disk.
+ * Atomic write: .tmp → fsync → rename → fsync parent dir.
+ * Single-writer queue with dirty flag prevents race conditions.
+ */
+function _createPersistEngine(filePath) {
+    let _timer = null;
+    let _pending = null;
+    let _dirty = false;
+    let _retries = 0;
+    let _lastError = null;
+    let _data = null;
+
+    async function _atomicFlush() {
+        const tmpPath = filePath + '.tmp';
+        const data = JSON.stringify(_data, null, 2);
+        const dirPath = path.dirname(filePath);
+
+        await fsPromises.writeFile(tmpPath, data, 'utf-8');
+
+        // fsync temp file to ensure data on disk
+        const fd = await fsPromises.open(tmpPath, 'r');
+        await fd.sync();
+        await fd.close();
+
+        // atomic rename
+        await fsPromises.rename(tmpPath, filePath);
+
+        // fsync parent dir to persist rename metadata
+        try {
+            const dirFd = await fsPromises.open(dirPath, 'r');
+            await dirFd.sync();
+            await dirFd.close();
+        } catch {
+            // dir fsync may fail on some OS/FS — rename already happened
+        }
+    }
+
+    function _scheduledFlush() {
+        if (_pending) {
+            _dirty = true;
+            return _pending;
+        }
+        _dirty = false;
+        _pending = _atomicFlush()
+            .then(() => {
+                _lastError = null;
+                _retries = 0;
+            })
+            .catch(err => {
+                _lastError = err;
+                _retries++;
+                if (_retries < MAX_FLUSH_RETRIES) {
+                    _dirty = true; // retry on next schedule
+                }
+                console.error(`[config] Settings flush failed (${filePath}):`, err.message);
+            })
+            .finally(() => {
+                _pending = null;
+                if (_dirty) {
+                    _dirty = false;
+                    _scheduledFlush();
+                }
+            });
+        return _pending;
+    }
+
+    function _schedulePersist() {
+        if (_timer) clearTimeout(_timer);
+        _timer = setTimeout(() => {
+            _timer = null;
+            _scheduledFlush();
+        }, DEBOUNCE_MS);
+    }
+
+    function save(updates) {
+        _data = { ..._data, ...updates };
+        _schedulePersist();
+        return _data;
+    }
+
+    function flushNow() {
+        if (_timer) {
+            clearTimeout(_timer);
+            _timer = null;
+        }
+        return _scheduledFlush();
+    }
+
+    function cancelPending() {
+        if (_timer) {
+            clearTimeout(_timer);
+            _timer = null;
+        }
+        _dirty = false;
+    }
+
+    return {
+        save,
+        flushNow,
+        cancelPending,
+        getData: () => _data,
+        setData: (d) => { _data = d; },
+    };
+}
+
 // --- Persistent settings ---
 const SETTINGS_PATH = path.join(__dirname, '..', 'settings.json');
 const DEFAULT_SETTINGS = {
@@ -22,6 +134,7 @@ const DEFAULT_SETTINGS = {
     defaultModel: 'MODEL_PLACEHOLDER_M26', // Claude Opus 4.6 (Thinking)
 };
 
+const _settingsEngine = _createPersistEngine(SETTINGS_PATH);
 let _settings = null;
 
 function loadSettings() {
@@ -36,17 +149,19 @@ function loadSettings() {
                 fs.copyFileSync(samplePath, SETTINGS_PATH);
             }
             _settings = { ...DEFAULT_SETTINGS };
-            saveSettings(_settings);
+            // Initial creation — sync write is acceptable (one-time, before event loop)
+            fs.writeFileSync(SETTINGS_PATH, JSON.stringify(_settings, null, 2), 'utf-8');
         }
     } catch {
         _settings = { ...DEFAULT_SETTINGS };
     }
+    // Seed engine with loaded data
+    _settingsEngine.setData(_settings);
     return _settings;
 }
 
 function saveSettings(updates) {
-    _settings = { ...loadSettings(), ...updates };
-    fs.writeFileSync(SETTINGS_PATH, JSON.stringify(_settings, null, 2), 'utf-8');
+    _settings = _settingsEngine.save({ ...loadSettings(), ...updates });
     return _settings;
 }
 
@@ -67,6 +182,7 @@ const DEFAULT_BRIDGE_SETTINGS = {
     lastRelayedStepIndex: -1,
 };
 
+const _bridgeEngine = _createPersistEngine(BRIDGE_SETTINGS_PATH);
 let _bridgeSettings = null;
 
 function loadBridgeSettings() {
@@ -80,12 +196,12 @@ function loadBridgeSettings() {
     } catch {
         _bridgeSettings = { ...DEFAULT_BRIDGE_SETTINGS };
     }
+    _bridgeEngine.setData(_bridgeSettings);
     return _bridgeSettings;
 }
 
 function saveBridgeSettings(updates) {
-    _bridgeSettings = { ...loadBridgeSettings(), ...updates };
-    fs.writeFileSync(BRIDGE_SETTINGS_PATH, JSON.stringify(_bridgeSettings, null, 2), 'utf-8');
+    _bridgeSettings = _bridgeEngine.save({ ...loadBridgeSettings(), ...updates });
     return _bridgeSettings;
 }
 
@@ -97,4 +213,7 @@ module.exports = {
     STEP_WINDOW_SIZE, STEP_LOAD_CHUNK,
     getSettings, saveSettings,
     getBridgeSettings, saveBridgeSettings,
+    flushSettingsNow: () => _settingsEngine.flushNow(),
+    flushBridgeSettingsNow: () => _bridgeEngine.flushNow(),
+    _cancelPendingFlush: () => { _settingsEngine.cancelPending(); _bridgeEngine.cancelPending(); },
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -131,11 +131,12 @@ function setupRoutes(app) {
         defaultModel: z.string().max(100).optional(),
     }).strict();
 
-    app.post('/api/settings', (req, res) => {
+    app.post('/api/settings', async (req, res) => {
         try {
             const validated = SettingsSchema.parse(req.body);
-            const { saveSettings } = require('./config');
+            const { saveSettings, flushSettingsNow } = require('./config');
             const updated = saveSettings(validated);
+            await flushSettingsNow();
             console.log(`[*] Settings updated:`, JSON.stringify(updated));
             res.json(updated);
         } catch (error) {
@@ -145,7 +146,8 @@ function setupRoutes(app) {
                     details: error.issues  // Zod v4 uses 'issues', not 'errors'
                 });
             }
-            throw error;
+            console.error('[*] Settings save failed:', error.message);
+            res.status(500).json({ error: 'Failed to persist settings' });
         }
     });
 
@@ -1433,17 +1435,19 @@ function setupRoutes(app) {
         res.json(getBridgeSettings());
     });
 
-    app.post('/api/agent-bridge/settings', (req, res) => {
+    app.post('/api/agent-bridge/settings', async (req, res) => {
         try {
             const validated = BridgeSettingsSchema.parse(req.body);
-            const { saveBridgeSettings } = require('./config');
+            const { saveBridgeSettings, flushBridgeSettingsNow } = require('./config');
             const updated = saveBridgeSettings(validated);
+            await flushBridgeSettingsNow();
             res.json(updated);
         } catch (error) {
             if (error instanceof z.ZodError) {
                 return res.status(400).json({ error: 'Invalid settings', details: error.issues });
             }
-            throw error;
+            console.error('[*] Bridge settings save failed:', error.message);
+            res.status(500).json({ error: 'Failed to persist bridge settings' });
         }
     });
 }

--- a/tests/config-persistence.test.js
+++ b/tests/config-persistence.test.js
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for config.js async persistence engine.
+ * Tests: sync return, debounce, atomic write, single-writer queue, flushSettingsNow, error handling.
+ */
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const fsPromises = require('fs/promises');
+const path = require('path');
+const os = require('os');
+
+/**
+ * Helper: create an isolated config module with a temp settings path.
+ * Patches SETTINGS_PATH and samplePath in a copy of config.js loaded fresh.
+ */
+function createIsolatedConfig(tmpDir) {
+    const settingsPath = path.join(tmpDir, 'settings.json');
+    const samplePath = path.join(tmpDir, 'settings.sample.json');
+
+    // Write a valid sample so loadSettings can bootstrap
+    fs.writeFileSync(samplePath, JSON.stringify({ defaultModel: 'test-model' }, null, 2));
+
+    // Patch config.js — replace paths, write to tmp, require fresh
+    const configSrc = fs.readFileSync(path.join(__dirname, '..', 'src', 'config.js'), 'utf-8');
+    const patched = configSrc
+        .replace(
+            /const SETTINGS_PATH = .*?;/,
+            `const SETTINGS_PATH = ${JSON.stringify(settingsPath)};`
+        )
+        .replace(
+            /const samplePath = .*?;/,
+            `const samplePath = ${JSON.stringify(samplePath)};`
+        );
+    const patchedPath = path.join(tmpDir, 'config-test.js');
+    fs.writeFileSync(patchedPath, patched);
+
+    delete require.cache[patchedPath];
+    const mod = require(patchedPath);
+    return { mod, settingsPath, samplePath, patchedPath };
+}
+
+describe('saveSettings() sync behavior', () => {
+    let tmpDir, mod;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        ({ mod } = createIsolatedConfig(tmpDir));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns updated settings synchronously', () => {
+        const result = mod.saveSettings({ testKey: 'hello' });
+        assert.equal(result.testKey, 'hello');
+    });
+
+    it('merges updates into existing settings', () => {
+        mod.saveSettings({ a: 1 });
+        const result = mod.saveSettings({ b: 2 });
+        assert.equal(result.a, 1);
+        assert.equal(result.b, 2);
+    });
+
+    it('does not block event loop (returns in <5ms)', () => {
+        const start = performance.now();
+        mod.saveSettings({ fast: true });
+        const elapsed = performance.now() - start;
+        assert.ok(elapsed < 5, `saveSettings took ${elapsed.toFixed(2)}ms, expected <5ms`);
+    });
+});
+
+describe('debounce', () => {
+    let tmpDir, mod, settingsPath;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        ({ mod, settingsPath } = createIsolatedConfig(tmpDir));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('coalesces rapid writes — file written after debounce, not per call', async () => {
+        for (let i = 0; i < 10; i++) {
+            mod.saveSettings({ counter: i });
+        }
+
+        // Wait for debounce + flush (750ms + buffer)
+        await new Promise(r => setTimeout(r, 1500));
+
+        const content = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(content.counter, 9, 'File should contain latest value');
+    });
+
+    it('uses latest _settings snapshot for flush', async () => {
+        mod.saveSettings({ val: 'first' });
+        mod.saveSettings({ val: 'second' });
+        mod.saveSettings({ val: 'third' });
+
+        await new Promise(r => setTimeout(r, 1500));
+
+        const content = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(content.val, 'third');
+    });
+});
+
+describe('atomic write', () => {
+    let tmpDir, mod, settingsPath;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        ({ mod, settingsPath } = createIsolatedConfig(tmpDir));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('settings.json always contains valid JSON after flush', async () => {
+        mod.saveSettings({ atomic: true });
+        await mod.flushSettingsNow();
+
+        const raw = fs.readFileSync(settingsPath, 'utf-8');
+        const parsed = JSON.parse(raw);
+        assert.equal(parsed.atomic, true);
+    });
+
+    it('.tmp file cleaned up after successful flush', async () => {
+        mod.saveSettings({ cleanup: true });
+        await mod.flushSettingsNow();
+
+        const tmpExists = fs.existsSync(settingsPath + '.tmp');
+        assert.equal(tmpExists, false, '.tmp file should not exist after flush');
+    });
+});
+
+describe('flushSettingsNow()', () => {
+    let tmpDir, mod, settingsPath;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        ({ mod, settingsPath } = createIsolatedConfig(tmpDir));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('bypasses debounce and writes immediately', async () => {
+        mod.saveSettings({ immediate: true });
+        const start = performance.now();
+        await mod.flushSettingsNow();
+        const elapsed = performance.now() - start;
+
+        assert.ok(elapsed < 500, `flushSettingsNow took ${elapsed.toFixed(0)}ms, expected <500ms`);
+
+        const content = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(content.immediate, true);
+    });
+
+    it('returns promise that resolves after write', async () => {
+        mod.saveSettings({ promised: 'value' });
+        await mod.flushSettingsNow();
+
+        const content = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(content.promised, 'value');
+    });
+
+    it('works when no pending changes', async () => {
+        await mod.flushSettingsNow();
+    });
+});
+
+describe('single-writer queue', () => {
+    let tmpDir, mod, settingsPath;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        ({ mod, settingsPath } = createIsolatedConfig(tmpDir));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('serializes concurrent flushes without error', async () => {
+        mod.saveSettings({ q1: true });
+        const p1 = mod.flushSettingsNow();
+        mod.saveSettings({ q2: true });
+        const p2 = mod.flushSettingsNow();
+
+        await Promise.all([p1, p2]);
+        // Dirty re-flush scheduled via debounce — wait for it
+        await new Promise(r => setTimeout(r, 1500));
+
+        const content = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(content.q1, true);
+        assert.equal(content.q2, true);
+    });
+
+    it('re-flushes if dirty during active flush', async () => {
+        mod.saveSettings({ phase: 'initial' });
+        const p1 = mod.flushSettingsNow();
+
+        // Update while flush is in progress — sets dirty flag
+        mod.saveSettings({ phase: 'updated-during-flush' });
+
+        await p1;
+        // Wait for debounced re-flush (750ms debounce + flush time)
+        await new Promise(r => setTimeout(r, 1500));
+
+        const content = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(content.phase, 'updated-during-flush');
+    });
+});
+
+describe('error handling', () => {
+    let tmpDir, mod;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        ({ mod } = createIsolatedConfig(tmpDir));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        try { await fsPromises.chmod(tmpDir, 0o755); } catch {}
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('logs error on write failure without crashing', async () => {
+        const errors = [];
+        const origError = console.error;
+        console.error = (...args) => errors.push(args.join(' '));
+
+        await fsPromises.chmod(tmpDir, 0o444);
+
+        mod.saveSettings({ willFail: true });
+        // Wait for debounce + flush attempt
+        await new Promise(r => setTimeout(r, 1500));
+
+        console.error = origError;
+        mod._cancelPendingFlush(); // stop retries before restoring dir
+        await fsPromises.chmod(tmpDir, 0o755);
+
+        assert.ok(errors.some(e => e.includes('flush failed')), 'Expected error log about flush failure');
+    });
+});
+
+describe('startup / init', () => {
+    it('loadSettings reads from file at startup', async () => {
+        const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        let mod;
+        try {
+            ({ mod } = createIsolatedConfig(tmpDir));
+            const settings = mod.getSettings();
+            assert.ok(settings.defaultModel, 'Should have loaded defaultModel from sample');
+        } finally {
+            if (mod) mod._cancelPendingFlush();
+            await fsPromises.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('creates settings.json from defaults if nothing exists', async () => {
+        const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-test-'));
+        let mod;
+        try {
+            ({ mod } = createIsolatedConfig(tmpDir));
+            const settings = mod.getSettings();
+            assert.ok(settings, 'Settings should be returned');
+        } finally {
+            if (mod) mod._cancelPendingFlush();
+            await fsPromises.rm(tmpDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/tests/settings-integration.test.js
+++ b/tests/settings-integration.test.js
@@ -1,0 +1,208 @@
+/**
+ * Integration tests for settings persistence.
+ * Tests: POST /api/settings end-to-end, bridge-style rapid saves, event loop lag.
+ */
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const fsPromises = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const http = require('http');
+
+/**
+ * Helper: create isolated config module with temp paths (same as unit tests).
+ */
+function createIsolatedConfig(tmpDir) {
+    const settingsPath = path.join(tmpDir, 'settings.json');
+    const samplePath = path.join(tmpDir, 'settings.sample.json');
+
+    fs.writeFileSync(samplePath, JSON.stringify({ defaultModel: 'test-model' }, null, 2));
+
+    const configSrc = fs.readFileSync(path.join(__dirname, '..', 'src', 'config.js'), 'utf-8');
+    const patched = configSrc
+        .replace(/const SETTINGS_PATH = .*?;/, `const SETTINGS_PATH = ${JSON.stringify(settingsPath)};`)
+        .replace(/const samplePath = .*?;/, `const samplePath = ${JSON.stringify(samplePath)};`);
+    const patchedPath = path.join(tmpDir, 'config-test.js');
+    fs.writeFileSync(patchedPath, patched);
+
+    delete require.cache[patchedPath];
+    const mod = require(patchedPath);
+    return { mod, settingsPath, patchedPath };
+}
+
+/**
+ * Helper: create a minimal Express app with just POST /api/settings.
+ * Avoids importing full routes.js (too many deps).
+ */
+function createTestApp(configMod) {
+    const express = require('express');
+    const app = express();
+    app.use(express.json());
+
+    app.post('/api/settings', async (req, res) => {
+        try {
+            const updated = configMod.saveSettings(req.body);
+            await configMod.flushSettingsNow();
+            res.json(updated);
+        } catch (error) {
+            res.status(500).json({ error: error.message });
+        }
+    });
+
+    app.get('/api/settings', (req, res) => {
+        res.json(configMod.getSettings());
+    });
+
+    return app;
+}
+
+/**
+ * Helper: send HTTP request and get response.
+ */
+function httpRequest(server, method, path, body) {
+    return new Promise((resolve, reject) => {
+        const addr = server.address();
+        const options = {
+            hostname: '127.0.0.1',
+            port: addr.port,
+            path,
+            method,
+            headers: { 'Content-Type': 'application/json' },
+        };
+        const req = http.request(options, res => {
+            let data = '';
+            res.on('data', chunk => { data += chunk; });
+            res.on('end', () => {
+                resolve({
+                    status: res.statusCode,
+                    body: data ? JSON.parse(data) : null,
+                });
+            });
+        });
+        req.on('error', reject);
+        if (body) req.write(JSON.stringify(body));
+        req.end();
+    });
+}
+
+describe('POST /api/settings (integration)', () => {
+    let tmpDir, mod, settingsPath, server;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-int-'));
+        ({ mod, settingsPath } = createIsolatedConfig(tmpDir));
+        const app = createTestApp(mod);
+        server = app.listen(0); // random port
+        await new Promise(r => server.once('listening', r));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        await new Promise(r => server.close(r));
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns 200 with updated settings', async () => {
+        const res = await httpRequest(server, 'POST', '/api/settings', { defaultModel: 'new-model' });
+        assert.equal(res.status, 200);
+        assert.equal(res.body.defaultModel, 'new-model');
+    });
+
+    it('persists to disk before response', async () => {
+        await httpRequest(server, 'POST', '/api/settings', { defaultModel: 'persisted' });
+
+        // Immediately read from disk — should already be there
+        const onDisk = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(onDisk.defaultModel, 'persisted');
+    });
+
+    it('handles concurrent POST requests', async () => {
+        const results = await Promise.all([
+            httpRequest(server, 'POST', '/api/settings', { defaultModel: 'a' }),
+            httpRequest(server, 'POST', '/api/settings', { defaultModel: 'b' }),
+            httpRequest(server, 'POST', '/api/settings', { defaultModel: 'c' }),
+        ]);
+
+        // All should return 200
+        for (const r of results) {
+            assert.equal(r.status, 200);
+        }
+
+        // File on disk should be valid JSON with one of the values
+        const onDisk = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.ok(['a', 'b', 'c'].includes(onDisk.defaultModel), `Expected one of a/b/c, got ${onDisk.defaultModel}`);
+    });
+});
+
+describe('bridge-style rapid saves (integration)', () => {
+    let tmpDir, mod, settingsPath;
+
+    beforeEach(async () => {
+        tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'cfg-int-'));
+        ({ mod, settingsPath } = createIsolatedConfig(tmpDir));
+    });
+
+    afterEach(async () => {
+        mod._cancelPendingFlush();
+        await fsPromises.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('coalesces rapid bridge state saves', async () => {
+        // Simulate bridge burst: 20 rapid saveSettings calls
+        for (let i = 0; i < 20; i++) {
+            mod.saveSettings({ agentBridge: { lastCascadeId: `cascade-${i}` } });
+        }
+
+        // Wait for debounce + flush
+        await new Promise(r => setTimeout(r, 1500));
+
+        const onDisk = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        assert.equal(onDisk.agentBridge.lastCascadeId, 'cascade-19', 'Should have last cascade ID');
+    });
+
+    it('does not block event loop during saves', async () => {
+        // Measure event loop lag while doing rapid saves
+        const lags = [];
+        let lastTick = Date.now();
+        let measuring = true;
+
+        function tick() {
+            const now = Date.now();
+            lags.push(now - lastTick - 1); // subtract expected 1ms delay
+            lastTick = now;
+            if (measuring) setTimeout(tick, 1);
+        }
+        setTimeout(tick, 1);
+
+        // Fire 50 rapid saves
+        for (let i = 0; i < 50; i++) {
+            mod.saveSettings({ bridgeCounter: i });
+        }
+
+        // Let event loop settle
+        await new Promise(r => setTimeout(r, 200));
+        measuring = false;
+        await new Promise(r => setTimeout(r, 50));
+
+        const maxLag = Math.max(...lags);
+        // With writeFileSync, each save blocks ~1-5ms → 50 saves = 50-250ms of blocking
+        // With async flush, max lag should be <10ms (just JS overhead)
+        assert.ok(maxLag < 50, `Max event loop lag was ${maxLag}ms, expected <50ms`);
+    });
+
+    it('survives simulated restart (write → read back)', async () => {
+        mod.saveSettings({ agentBridge: { lastCascadeId: 'survive-test' } });
+        await mod.flushSettingsNow();
+
+        // Simulate restart: clear require cache, reload
+        const patchedPath = path.join(tmpDir, 'config-test.js');
+        delete require.cache[patchedPath];
+        const freshMod = require(patchedPath);
+
+        const settings = freshMod.getSettings();
+        assert.equal(settings.agentBridge.lastCascadeId, 'survive-test');
+
+        freshMod._cancelPendingFlush();
+    });
+});


### PR DESCRIPTION
fix: replace writeFileSync with async debounced atomic flush in config.js

  saveSettings() and saveBridgeSettings() blocked the event loop with
  synchronous file writes on every call. During bridge cascade bursts,
  this caused 1-100ms blocking per save.

  Introduce _createPersistEngine() factory with:
  - Sync in-memory update + 750ms debounced background flush
  - Atomic write (.tmp → fsync → rename → fsync dir)
  - Single-writer queue with dirty flag to prevent races
  - MAX_FLUSH_RETRIES=3 to prevent infinite retry storms
  - flushSettingsNow()/flushBridgeSettingsNow() for confirmed persistence

  Migrate POST /api/settings and POST /api/agent-bridge/settings to
  await flush before HTTP 200. Fire-and-forget callers unchanged.

  Add unit tests (15) and integration tests (6) — all pass.