### PR TITLE
fix: new chat button opens chat directly instead of conversation list

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -252,11 +252,8 @@ export default function Home() {
     setWsVersion(v => v + 1);
   }, []);
 
-  // ChatView's "New Chat" button — go back to conversation list
-  const handleNewConversation = useCallback(() => {
-    selectConversation(null);
-    setNewChatMode(false);
-  }, [selectConversation]);
+  // ChatView's "New Chat" button — enter new chat mode directly
+  // Reuses handleNewChat logic: clear conversation + enable newChatMode
 
 
 
@@ -595,7 +592,7 @@ export default function Home() {
                 wsVersion={wsVersion}
                 cascadeStatus={cascadeStatus ?? undefined}
                 onCascadeCreated={handleCascadeCreated}
-                onNewConversation={handleNewConversation}
+                onNewConversation={handleNewChat}
                 showTimeline={showTimeline}
                 onSetShowTimeline={handleSetShowTimeline}
                 showAnalytics={showAnalytics}


### PR DESCRIPTION
 ## Summary
  - **Bug:** Clicking "New Chat" inside ChatView navigated to conversation list instead of opening a new chat directly
  - **Root cause:** `handleNewConversation` set `newChatMode(false)` — should be `true`
  - **Fix:** Removed redundant `handleNewConversation` handler, reused existing `handleNewChat` which correctly enables new chat mode

  ## Changes
  - `frontend/app/page.tsx`: Replaced `onNewConversation={handleNewConversation}` with `onNewConversation={handleNewChat}`; removed dead `handleNewConversation` callback