### PR TITLE
fix: use ipKeyGenerator for IPv6-safe rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const { init, startAutoRescan } = require('./src/detector');
 const { setupRoutes } = require('./src/routes');
 const { setupWebSocket, startPolling } = require('./src/cache');
 const helmet = require('helmet');
-const rateLimit = require('express-rate-limit');
+const { rateLimit, ipKeyGenerator } = require('express-rate-limit');
 const morgan = require('morgan');
 const rfs = require('rotating-file-stream');
 const fs = require('fs');
@@ -136,7 +136,7 @@ const generalLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later.' },
-  keyGenerator: (req) => req.headers['cf-connecting-ip'] || req.ip,
+  keyGenerator: (req) => req.headers['cf-connecting-ip'] || ipKeyGenerator(req),
 });
 
 const strictLimiter = rateLimit({
@@ -145,7 +145,7 @@ const strictLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many authentication attempts, please try again later.' },
-  keyGenerator: (req) => req.headers['cf-connecting-ip'] || req.ip,
+  keyGenerator: (req) => req.headers['cf-connecting-ip'] || ipKeyGenerator(req),
   skipSuccessfulRequests: true,
 });
 


### PR DESCRIPTION
## Problem
The express-rate-limit v7+ throws ERR_ERL_KEY_GEN_IPV6 validation error on startup because the custom keyGenerator uses raw eq.ip as fallback, which doesn't handle IPv6 normalization.

## Fix
- Import ipKeyGenerator from express-rate-limit`n- Replace eq.ip fallback with ipKeyGenerator(req) in both generalLimiter and strictLimiter`n
This ensures IPv6 addresses are properly normalized so users can't bypass rate limits using different IPv6 representations.