### PR TITLE
feat: add Launch Antigravity button on welcome screen

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -7,7 +7,9 @@ import { extractStepContent, exportToMarkdown } from '@/lib/step-utils';
 import { Timeline } from '@/components/timeline';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
-import { MoreVertical, BarChart2, Download, Bell, BellOff, FolderSync, Star, WifiOff, FolderOpen } from 'lucide-react';
+import { MoreVertical, BarChart2, Download, Bell, BellOff, FolderSync, Star, WifiOff, FolderOpen, Rocket, Loader2, Check } from 'lucide-react';
+import { API_BASE } from '@/lib/config';
+import { authHeaders } from '@/lib/auth';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -39,6 +41,49 @@ function getStoredValue<T>(key: string, fallback: T): T {
     if (stored === null) return fallback;
     return JSON.parse(stored) as T;
   } catch { return fallback; }
+}
+
+/** Button to launch the Antigravity IDE from the welcome screen. */
+function LaunchIdeButton() {
+  const [state, setState] = useState<'idle' | 'launching' | 'launched'>('idle');
+
+  const handleLaunch = useCallback(async () => {
+    if (state !== 'idle') return;
+    setState('launching');
+    try {
+      await fetch(`${API_BASE}/api/launch-ide`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+      });
+      setState('launched');
+      // Reset after 15s cooldown
+      setTimeout(() => setState('idle'), 15000);
+    } catch {
+      setState('idle');
+    }
+  }, [state]);
+
+  return (
+    <button
+      onClick={handleLaunch}
+      disabled={state !== 'idle'}
+      className={`inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 ${
+        state === 'launched'
+          ? 'bg-emerald-500/15 text-emerald-400 border border-emerald-500/30 cursor-default'
+          : state === 'launching'
+            ? 'bg-primary/10 text-primary border border-primary/30 cursor-wait'
+            : 'bg-primary/15 text-primary border border-primary/30 hover:bg-primary/25 hover:border-primary/50 cursor-pointer'
+      }`}
+    >
+      {state === 'launched' ? (
+        <><Check className="w-4 h-4" /> Launched — waiting for detection...</>
+      ) : state === 'launching' ? (
+        <><Loader2 className="w-4 h-4 animate-spin" /> Launching...</>
+      ) : (
+        <><Rocket className="w-4 h-4" /> Launch Antigravity</>
+      )}
+    </button>
+  );
 }
 
 export default function Home() {
@@ -502,6 +547,7 @@ export default function Home() {
                     </li>
                   ))}
                 </ol>
+                <LaunchIdeButton />
                 <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground/70">
                   <span className="relative flex h-2 w-2">
                     <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-400/75" />

--- a/frontend/components/auth-gate.tsx
+++ b/frontend/components/auth-gate.tsx
@@ -81,7 +81,7 @@ export function AuthGate({ children }: AuthGateProps) {
     if (authenticated) return <>{children}</>;
 
     return (
-        <div className="min-h-dvh bg-background flex items-center justify-center p-4">
+        <div className="min-h-dvh w-full bg-background flex items-center justify-center p-4">
             <Card className="w-full max-w-sm">
                 <CardHeader className="text-center pb-2">
                     <div className="mb-3"><Lock className="h-8 w-8 text-muted-foreground mx-auto" /></div>

--- a/server.js
+++ b/server.js
@@ -212,8 +212,9 @@ if (AUTH_KEY) {
     next();
   });
   
-  // Apply strict rate limiter to settings endpoint (sensitive operations)
+  // Apply strict rate limiter to sensitive operations
   app.use('/api/settings', strictLimiter);
+  app.use('/api/launch-ide', strictLimiter);
 } else {
   console.log('  ⚠️  No AUTH_KEY set — API is open (safe for local dev)');
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -114,6 +114,65 @@ function setupRoutes(app) {
         res.json({ detected: lsInstances.length > 0, port: firstInst?.port || null });
     });
 
+    // Launch IDE — fire-and-forget, opens the Antigravity IDE application
+    // Security: no user input, rate-limited via strictLimiter in server.js, auth-protected
+    app.post('/api/launch-ide', (req, res) => {
+        const { platform } = require('./config');
+        console.log(`[*] Launch IDE requested (platform: ${platform})`);
+
+        try {
+            if (platform === 'darwin') {
+                // macOS: try Antigravity first, fallback to Windsurf
+                const child = spawn('open', ['-a', 'Antigravity'], {
+                    timeout: 10000,
+                    detached: true,
+                    stdio: 'ignore'
+                });
+
+                child.on('error', () => {
+                    console.log('[*] Antigravity app not found, trying Windsurf...');
+                    const fallback = spawn('open', ['-a', 'Windsurf'], {
+                        timeout: 10000, detached: true, stdio: 'ignore'
+                    });
+                    fallback.on('error', (e) => console.error('[!] Failed to open IDE:', e.message));
+                    fallback.unref();
+                });
+
+                child.on('exit', (code) => {
+                    if (code !== 0 && code !== null) {
+                        console.log(`[*] Antigravity exited with code ${code}, trying Windsurf...`);
+                        const fallback = spawn('open', ['-a', 'Windsurf'], {
+                            timeout: 10000, detached: true, stdio: 'ignore'
+                        });
+                        fallback.on('error', (e) => console.error('[!] Failed to open IDE:', e.message));
+                        fallback.unref();
+                    }
+                });
+
+                child.unref();
+            } else {
+                // Windows/Linux
+                const child = spawn('antigravity', [], {
+                    timeout: 10000,
+                    detached: true,
+                    stdio: 'ignore',
+                    shell: platform === 'win32',
+                });
+
+                child.on('error', (err) => {
+                    console.error('[!] Failed to launch antigravity:', err.message);
+                });
+
+                child.unref();
+            }
+
+            res.json({ launched: true, platform });
+        } catch (e) {
+            console.error('[!] Launch IDE error:', e.message);
+            res.status(500).json({ error: 'Failed to launch IDE' });
+        }
+    });
+
     // Clear cache for a specific conversation — see also app.delete('/api/cache/:id') below
     // (consolidated into single handler below)
 


### PR DESCRIPTION
- New POST /api/launch-ide endpoint with cross-platform spawn (macOS: Antigravity/Windsurf fallback, Windows: shell spawn)
- Strict rate limiter (5 req/15min) on launch-ide endpoint
- LaunchIdeButton component with idle/launching/launched states
- Fix auth gate card off-center on mobile (add w-full)