### PR TITLE
perf: replace agent-bridge status polling with WebSocket push

### DIFF
--- a/frontend/components/agent-bridge-view.tsx
+++ b/frontend/components/agent-bridge-view.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import { API_BASE } from '@/lib/config';
 import { authHeaders } from '@/lib/auth';
+import { wsService } from '@/lib/ws-service';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -87,7 +88,6 @@ export function AgentBridgeView() {
     const [error, setError] = useState<string | null>(null);
     const [settingsLoaded, setSettingsLoaded] = useState(false);
     const bottomRef = useRef<HTMLDivElement>(null);
-    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     // Load persistent settings from backend
     const loadSettings = useCallback(async () => {
@@ -111,9 +111,14 @@ export function AgentBridgeView() {
 
     useEffect(() => {
         loadSettings();
-        fetchStatus();
-        pollRef.current = setInterval(fetchStatus, 3000);
-        return () => { if (pollRef.current) clearInterval(pollRef.current); };
+        fetchStatus(); // initial fetch only — subsequent updates via WebSocket
+
+        // Subscribe to real-time bridge status updates via existing WS
+        if (!wsService) return;
+        const off = wsService.on('bridge_status', (data) => {
+            setStatus(data as unknown as BridgeStatus);
+        });
+        return off;
     }, [loadSettings, fetchStatus]);
 
     useEffect(() => {

--- a/src/agent-bridge.js
+++ b/src/agent-bridge.js
@@ -603,6 +603,11 @@ function addLog(type, message) {
         const logPath = path.join(__dirname, '..', 'bridge.log');
         fs.appendFileSync(logPath, `${new Date().toISOString()} ${line}\n`);
     } catch { /* ignore write errors */ }
+    // Push status to all connected WS clients (replaces frontend polling)
+    try {
+        const { broadcastAll } = require('./ws');
+        broadcastAll({ type: 'bridge_status', ...getStatus() });
+    } catch { /* ws not ready yet */ }
 }
 
 // ── Exports ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Changes
- Remove 3-second setInterval polling of /api/agent-bridge/status
- Broadcast bridge_status via existing WebSocket in addLog()
- Frontend subscribes via wsService.on('bridge_status')
- Keep REST endpoint for initial load and manual refresh

## Impact
- Eliminates ~20 HTTP requests/minute when bridge view is open
- Updates are now instant (push) instead of delayed (poll)
- Zero new dependencies