### PR TITLE
feat: smart auto-scroll to latest chat message

### DIFF
--- a/frontend/components/chat-view.tsx
+++ b/frontend/components/chat-view.tsx
@@ -114,17 +114,37 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
     const wsPickerRef = useRef<HTMLDivElement>(null);
     const modelPickerRef = useRef<HTMLDivElement>(null);
 
-    // Chat scroll — autoScroll as ref to avoid re-renders on scroll events (rerender-use-ref-transient-values)
+    // Chat scroll — autoScroll as ref to avoid re-renders on scroll events
     const bottomRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const autoScrollRef = useRef(true);
-    // Guard: true while a programmatic scroll animation is in progress
-    // Prevents handleScroll from misinterpreting programmatic scroll events as user intent
-    const isProgrammaticScrollRef = useRef(false);
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
     // Snapshot of sent images for optimistic rendering (survives state clear)
     const pendingMediaRef = useRef<{ dataUrl: string; mimeType: string; name: string }[]>([]);
+
+    // Detect REAL user scroll via wheel/touch events (these NEVER fire from programmatic scrollIntoView)
+    // This is the key to distinguishing user intent from auto-scroll
+    const userScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const isUserScrollingRef = useRef(false);
+    useEffect(() => {
+        const el = containerRef.current;
+        if (!el) return;
+        const markUserScroll = () => {
+            isUserScrollingRef.current = true;
+            clearTimeout(userScrollTimeoutRef.current);
+            userScrollTimeoutRef.current = setTimeout(() => {
+                isUserScrollingRef.current = false;
+            }, 150);
+        };
+        el.addEventListener('wheel', markUserScroll, { passive: true });
+        el.addEventListener('touchstart', markUserScroll, { passive: true });
+        return () => {
+            el.removeEventListener('wheel', markUserScroll);
+            el.removeEventListener('touchstart', markUserScroll);
+            clearTimeout(userScrollTimeoutRef.current);
+        };
+    }, []);
 
     // Reset textarea height when input is cleared (e.g. after send)
     useEffect(() => {
@@ -134,13 +154,9 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
     }, [input]);
 
     // Auto-scroll: triggers on new steps (length change) AND streaming content updates (wsVersion)
-    // Uses isProgrammaticScrollRef guard so handleScroll ignores these programmatic scrolls
     useEffect(() => {
         if (autoScrollRef.current && bottomRef.current) {
-            isProgrammaticScrollRef.current = true;
             bottomRef.current.scrollIntoView({ behavior: 'smooth' });
-            // Clear guard after scroll animation completes (~400ms for smooth scroll)
-            setTimeout(() => { isProgrammaticScrollRef.current = false; }, 400);
         } else if (steps.length > prevStepsLenRef.current) {
             // New steps arrived but user is scrolled up — show button
             setShowScrollBtn(true);
@@ -152,9 +168,7 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
     useEffect(() => {
         const el = containerRef.current;
         if (el && baseIndex < prevBaseIndexRef.current && steps.length > prevStepsLenRef.current) {
-            // Older steps were prepended — estimate added height and adjust scroll
             const addedCount = steps.length - prevStepsLenRef.current;
-            // ~80px per step is a reasonable estimate; requestAnimationFrame ensures DOM is updated
             requestAnimationFrame(() => {
                 el.scrollTop += addedCount * 80;
             });
@@ -164,25 +178,24 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
 
     const handleScroll = useCallback(() => {
         if (!containerRef.current) return;
-        // Ignore scroll events fired by programmatic scrollIntoView calls
-        // This prevents auto-scroll from re-enabling when user hasn't intentionally scrolled
-        if (isProgrammaticScrollRef.current) return;
         const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
-        const atBottom = scrollHeight - scrollTop <= clientHeight + 100;
-        autoScrollRef.current = atBottom;
-        if (atBottom) setShowScrollBtn(false);
-        // Scroll-up: trigger load older steps when near top
+        // Only update autoScroll state from REAL user scrolls (wheel/touch)
+        // Programmatic scrollIntoView fires scroll events but NOT wheel/touch events
+        if (isUserScrollingRef.current) {
+            const atBottom = scrollHeight - scrollTop <= clientHeight + 100;
+            autoScrollRef.current = atBottom;
+            if (atBottom) setShowScrollBtn(false);
+        }
+        // Always check: load older steps when near top
         if (scrollTop < 100 && baseIndex > 0 && !loadingOlder && onLoadOlder) {
             onLoadOlder();
         }
     }, [baseIndex, loadingOlder, onLoadOlder]);
 
     const scrollToBottom = useCallback(() => {
-        isProgrammaticScrollRef.current = true;
         bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
         autoScrollRef.current = true;
         setShowScrollBtn(false);
-        setTimeout(() => { isProgrammaticScrollRef.current = false; }, 400);
     }, []);
 
     // Load workspaces + models + settings in parallel
@@ -222,10 +235,7 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
         autoScrollRef.current = true;
         // Use a short delay to let the DOM render the new steps first
         const timer = setTimeout(() => {
-            isProgrammaticScrollRef.current = true;
             bottomRef.current?.scrollIntoView({ behavior: 'instant' });
-            // Shorter guard for instant scroll
-            setTimeout(() => { isProgrammaticScrollRef.current = false; }, 100);
         }, 50);
         return () => clearTimeout(timer);
     }, [currentConvId]);


### PR DESCRIPTION
## What
Mỗi lần vào chat, tự động scroll xuống tin nhắn mới nhất. Khi agent đang stream mà user cuộn lên đọc → không bị kéo xuống.

## How
- Thêm useEffect scroll to bottom khi switch conversation (currentConvId change)
- Dùng wheel/	ouchstart event listener để phân biệt user scroll vs programmatic scroll
- handleScroll chỉ update utoScrollRef khi detect real user scroll
- Auto-scroll chỉ active khi user đang ở cuối chat

## Behavior
| Scenario | Action |
|---|---|
| Enter/switch chat | Scroll to bottom ✅ |
| At bottom + new message | Smooth auto-scroll ✅ |
| User scrolls up | Stop auto-scroll, show button ✅ |
| User scrolls back to bottom | Resume auto-scroll ✅ |