### PR TITLE
refactor: consolidate all launch logic into start-tunnel.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "setup": "npm install && npm install --prefix frontend && node -e \"const fs=require('fs');if(!fs.existsSync('settings.json'))fs.copyFileSync('settings.sample.json','settings.json');console.log('✅ Setup complete! Run: npm run dev')\"",
     "start": "node server.js",
     "dev": "concurrently -n BE,FE -c cyan,magenta \"node --watch server.js\" \"npm run dev --prefix frontend\"",
-    "prod": "npm run build --prefix frontend && concurrently -n BE,FE -c cyan,magenta \"node server.js\" \"npm run start --prefix frontend\"",
+    "prod": "node start-tunnel.js --local",
     "server": "node --watch server.js",
     "tunnel:be": "cloudflared tunnel --url http://localhost:3500",
     "tunnel:fe": "cloudflared tunnel --url http://localhost:3000",

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -217,115 +217,13 @@ if (-not (Test-Path "settings.json")) {
     Write-Host "  [OK] Created settings.json from sample" -ForegroundColor Green
 }
 
-# === Build frontend (production) ===
-$needBuild = $false
-
-switch ($scenario) {
-    "fresh" {
-        $needBuild = $true
-    }
-    "updated" {
-        # Rebuild if any frontend source files changed
-        $feSourceChanged = $updatedFiles | Where-Object {
-            $_ -like "frontend/*" -and $_ -notlike "frontend/node_modules/*"
-        }
-        if ($feSourceChanged) {
-            $needBuild = $true
-        }
-    }
-    "up-to-date" {
-        # Build if .next folder is missing (user may have deleted it)
-        if (-not (Test-Path "frontend\.next")) {
-            $needBuild = $true
-        }
-    }
-}
-
-if ($needBuild) {
-    Write-Host ""
-    Write-Host "  [i] Building frontend (production)..." -ForegroundColor Cyan
-    $env:BACKEND_PORT = "9807"
-    npm run build --prefix frontend
-    Write-Host "  [OK] Frontend build complete" -ForegroundColor Green
-}
-else {
-    Write-Host "  [OK] Frontend build -- no changes" -ForegroundColor Green
-}
-
-# === Summary ===
+# === Launch ===
 Write-Host ""
-Write-Host "  ======================================" -ForegroundColor DarkGray
-switch ($scenario) {
-    "fresh"      { Write-Host "  Fresh install complete!" -ForegroundColor Green }
-    "updated"    { Write-Host "  Updated and ready!" -ForegroundColor Green }
-    "up-to-date" { Write-Host "  Already up to date!" -ForegroundColor Green }
-}
-Write-Host "  ======================================" -ForegroundColor DarkGray
+Write-Host "  Starting Antigravity Deck..." -ForegroundColor Green
 Write-Host ""
 
-# === Launch (BE=9807, FE=9808) ===
-
-# Kill any existing processes on our ports
-$ports = @(9807, 9808)
-foreach ($port in $ports) {
-    $existing = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
-    if ($existing) {
-        foreach ($conn in $existing) {
-            $procId = $conn.OwningProcess
-            $procName = (Get-Process -Id $procId -ErrorAction SilentlyContinue).ProcessName
-            Write-Host "  [!] Killing stale process on port $port (PID $procId, $procName)" -ForegroundColor Yellow
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-        }
-        Start-Sleep -Seconds 1
-    }
-}
-
-# Start backend on port 9807
-$env:NODE_ENV = "production"
-$env:PORT = "9807"
-$env:BACKEND_PORT = "9807"
-$beProc = Start-Process -FilePath "node" -ArgumentList "server.js" -NoNewWindow -PassThru
-
-Write-Host "  Starting Antigravity Deck (production)..." -ForegroundColor Green
-Write-Host "  Backend:  http://localhost:9807" -ForegroundColor DarkGray
-Write-Host "  Frontend: http://localhost:9808" -ForegroundColor DarkGray
-
-if (-not $cfFound) {
-    Write-Host "  (Install cloudflared for remote access: winget install cloudflare.cloudflared)" -ForegroundColor DarkGray
-}
-
-Write-Host ""
-Write-Host "  Press Ctrl+C to stop" -ForegroundColor DarkGray
-Write-Host ""
-
-# Cleanup function — kills backend + any remaining port listeners
-function Cleanup-All {
-    Write-Host ""
-    Write-Host "  Shutting down..." -ForegroundColor Yellow
-    try {
-        if ($beProc -and -not $beProc.HasExited) {
-            taskkill /PID $beProc.Id /T /F 2>$null | Out-Null
-        }
-    } catch {}
-    foreach ($port in @(9807, 9808)) {
-        $conns = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
-        foreach ($conn in $conns) {
-            Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
-        }
-    }
-    Get-Process -Name "cloudflared" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-    Write-Host "  All processes stopped." -ForegroundColor Green
-    Write-Host ""
-}
-
-Register-EngineEvent PowerShell.Exiting -Action { Cleanup-All } -ErrorAction SilentlyContinue | Out-Null
-
-# Start frontend production server on port 9808
-try {
-    Push-Location frontend
-    $env:BACKEND_PORT = "9807"
-    npx next start --port 9808
-}
-catch {
-    Cleanup-All
+if ($cfFound) {
+    node start-tunnel.js --quiet --build
+} else {
+    node start-tunnel.js --local --build
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -184,109 +184,14 @@ if [ ! -f "settings.json" ]; then
     echo "  📝 Created settings.json from sample"
 fi
 
-# === Build frontend (production) ===
-need_build=false
 
-case "$scenario" in
-    "fresh")
-        need_build=true
-        ;;
-    "updated")
-        # Rebuild if any frontend source files changed
-        if echo "$updated_files" | grep -q "^frontend/"; then
-            need_build=true
-        fi
-        ;;
-    "up-to-date")
-        # Build if .next folder is missing
-        if [ ! -d "frontend/.next" ]; then
-            need_build=true
-        fi
-        ;;
-esac
+# === Launch ===
+echo ""
+echo "  Starting Antigravity Deck..."
+echo ""
 
-if $need_build; then
-    echo ""
-    echo "  🔨 Building frontend (production)..."
-    export BACKEND_PORT=9807
-    npm run build --prefix frontend
-    echo "  ✅ Frontend build complete"
+if $cf_found; then
+    node start-tunnel.js --quiet --build
 else
-    echo "  ✅ Frontend build — no changes"
+    node start-tunnel.js --local --build
 fi
-
-# === Summary ===
-echo ""
-echo "  ─────────────────────────────────────"
-case "$scenario" in
-    "fresh")      echo "  🎉 Fresh install complete!" ;;
-    "updated")    echo "  🔄 Updated and ready!" ;;
-    "up-to-date") echo "  ⚡ Already up to date!" ;;
-esac
-echo "  ─────────────────────────────────────"
-echo ""
-
-# === Launch (BE=9807, FE=9808) ===
-
-# Kill any existing processes on our ports
-for port in 9807 9808; do
-    pids=""
-    if command -v lsof &>/dev/null; then
-        pids=$(lsof -ti ":$port" 2>/dev/null)
-    elif command -v fuser &>/dev/null; then
-        pids=$(fuser "$port/tcp" 2>/dev/null | tr -s ' ')
-    fi
-    if [ -n "$pids" ]; then
-        for p in $pids; do
-            echo "  [!] Killing stale process on port $port (PID $p)"
-            kill -9 "$p" 2>/dev/null
-        done
-        sleep 1
-    fi
-done
-
-# Start backend on port 9807
-export NODE_ENV=production
-export PORT=9807
-export BACKEND_PORT=9807
-node server.js &
-BE_PID=$!
-
-echo "  Starting Antigravity Deck (production)..."
-echo "  Backend:  http://localhost:9807"
-echo "  Frontend: http://localhost:9808"
-
-if ! $cf_found; then
-    if [[ "$(uname)" == "Darwin" ]]; then
-        echo "  (Install cloudflared for remote access: brew install cloudflared)"
-    else
-        echo "  (Install cloudflared for remote access: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/)"
-    fi
-fi
-
-echo ""
-echo "  Press Ctrl+C to stop"
-echo ""
-
-# Cleanup function — kills backend + any remaining port listeners
-cleanup() {
-    echo ""
-    echo "  Shutting down..."
-    kill $BE_PID 2>/dev/null
-    for port in 9807 9808; do
-        if command -v lsof &>/dev/null; then
-            lsof -ti ":$port" 2>/dev/null | xargs kill -9 2>/dev/null
-        elif command -v fuser &>/dev/null; then
-            fuser -k "$port/tcp" 2>/dev/null
-        fi
-    done
-    pkill -f "cloudflared.*tunnel.*localhost" 2>/dev/null
-    echo "  All processes stopped."
-    echo ""
-    exit 0
-}
-
-trap cleanup INT TERM HUP EXIT
-
-# Start frontend production server on port 9808
-cd frontend && BACKEND_PORT=9807 npx next start --port 9808

--- a/start-tunnel.js
+++ b/start-tunnel.js
@@ -1,152 +1,100 @@
-// === start-tunnel.js — One-command internet deployment ===
-// Starts: Backend → BE Tunnel → Frontend (with BE URL injected) → FE Tunnel
-// Usage: node start-tunnel.js
+// === start-tunnel.js — Production launcher for Antigravity Deck ===
+// Usage:
+//   node start-tunnel.js           → build + start + Cloudflare tunnels
+//   node start-tunnel.js --local   → build + start locally (no tunnels)
+//   node start-tunnel.js --build   → force rebuild even if .next exists
 
 const { spawn, execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const FE_PORT = 9808;  // Online FE port (dev uses 3000)
-const BE_PORT = 9807;  // Online BE port (dev uses 3500) — 9.8 m/s² 🪐
-let beUrl = null;
-let feUrl = null;
+// === Port configuration (single source of truth) ===
+const FE_PORT = 9808;  // Production FE port (dev uses 3000)
+const BE_PORT = 9807;  // Production BE port (dev uses 3500) — 9.8 m/s² 🪐
 
 const IS_MAC = process.platform === 'darwin';
 const IS_WIN = process.platform === 'win32';
+const LOCAL_MODE = process.argv.includes('--local');
+const FORCE_BUILD = process.argv.includes('--build');
+const QUIET = process.env.QUIET === '1' || process.argv.includes('--quiet');
+
+let beUrl = null;
+let feUrl = null;
+const allProcs = []; // Track all spawned processes for cleanup
 
 // Find cloudflared binary — may not be in PATH on Windows/macOS
 function findCloudflared() {
-    // Try PATH first
     try { execSync('cloudflared --version', { stdio: 'ignore' }); return 'cloudflared'; } catch { }
-    // Common install locations per OS
     const paths = IS_WIN
-        ? [
-            'C:\\Program Files (x86)\\cloudflared\\cloudflared.exe',
-            'C:\\Program Files\\cloudflared\\cloudflared.exe',
-        ]
-        : [
-            '/opt/homebrew/bin/cloudflared',   // Apple Silicon Homebrew
-            '/usr/local/bin/cloudflared',       // Intel Homebrew
-        ];
+        ? ['C:\\Program Files (x86)\\cloudflared\\cloudflared.exe', 'C:\\Program Files\\cloudflared\\cloudflared.exe']
+        : ['/opt/homebrew/bin/cloudflared', '/usr/local/bin/cloudflared'];
     for (const p of paths) {
         if (fs.existsSync(p)) return IS_WIN ? `"${p}"` : p;
     }
     return null;
 }
 const CLOUDFLARED = findCloudflared();
-const QUIET = process.env.QUIET === '1' || process.argv.includes('--quiet');
 
 function log(tag, msg) {
-    if (QUIET) return;  // In quiet mode, suppress ALL process logs
+    if (QUIET) return;
     const colors = { BE: '\x1b[36m', FE: '\x1b[35m', 'TUN-BE': '\x1b[32m', 'TUN-FE': '\x1b[33m', '*': '\x1b[1m' };
     const reset = '\x1b[0m';
     console.log(`${colors[tag] || ''}[${tag}]${reset} ${msg}`);
 }
 
-// Quiet-mode progress: overwrite same line with status
 function progress(msg) {
-    if (QUIET) {
-        process.stdout.write(`\r\x1b[K  ${msg}`);
-    }
+    if (QUIET) process.stdout.write(`\r\x1b[K  ${msg}`);
 }
 
 // Extract Cloudflare tunnel URL from process output
 function extractTunnelUrl(text) {
-    // Strip all whitespace/newlines to handle URL being split across lines
     const stripped = text.replace(/\s+/g, '');
-    // Require at least one hyphen in subdomain — real tunnel URLs are like
-    // "willing-keeps-listen-perform.trycloudflare.com", not "api.trycloudflare.com"
     const match = stripped.match(/(https:\/\/[a-z0-9]+-[a-z0-9-]+\.trycloudflare\.com)/);
     return match ? match[1] : null;
 }
 
-// Start a process and return it
+// Start a process, track it for cleanup
 function startProcess(name, cmd, args, opts = {}) {
-    // In quiet mode, completely discard child process output
-    const childStdio = QUIET
-        ? ['ignore', 'ignore', 'ignore']
-        : ['ignore', 'pipe', 'pipe'];
+    const childStdio = QUIET ? ['ignore', 'ignore', 'ignore'] : ['ignore', 'pipe', 'pipe'];
     const proc = spawn(cmd, args, { stdio: childStdio, shell: true, ...opts });
     if (!QUIET) {
         proc.stdout?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log(name, l.trim())));
         proc.stderr?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log(name, l.trim())));
     }
     proc.on('exit', code => log(name, `exited with code ${code}`));
+    allProcs.push(proc);
     return proc;
 }
 
-async function main() {
-    // Check cloudflared first
-    if (!CLOUDFLARED) {
-        console.log('\n\x1b[31m  ❌ cloudflared not found!\x1b[0m');
-        const installCmd = IS_MAC
-            ? 'brew install cloudflared'
-            : 'winget install cloudflare.cloudflared';
-        console.log(`  Install: ${installCmd}\n`);
-        process.exit(1);
-    }
-    log('*', `Using cloudflared: ${CLOUDFLARED}`);
-
-    // Generate a random auth key for this session
-    const crypto = require('crypto');
-    const authKey = process.env.AUTH_KEY || crypto.randomBytes(16).toString('hex');
-
-    if (!QUIET) {
-        console.log('\n\x1b[1m  🚀 AntigravityChat — Starting with Cloudflare Tunnel\x1b[0m');
-        console.log(`  🔑 Auth Key: \x1b[33m${authKey}\x1b[0m\n`);
-    }
-
-    // Step 1: Start backend on online port (quiet polling to reduce log noise)
-    progress('Starting backend...');
-    log('*', `Starting backend on port ${BE_PORT}...`);
-    const be = startProcess('BE', 'node', ['server.js'], {
-        cwd: __dirname,
-        env: { ...process.env, PORT: String(BE_PORT), AUTH_KEY: authKey, QUIET_POLL: '1' }
-    });
-
-    // Wait for backend to be ready
-    await new Promise(resolve => setTimeout(resolve, 3000));
-
-    // Step 2: Start backend tunnel
-    progress('Starting backend tunnel...');
-    log('*', 'Starting Cloudflare tunnel for backend...');
-    const tunBe = spawn(CLOUDFLARED, ['tunnel', '--url', `http://localhost:${BE_PORT}`], {
-        stdio: ['ignore', 'pipe', 'pipe'], shell: true
-    });
-
-    // Capture backend tunnel URL
-    beUrl = await new Promise((resolve) => {
-        const timeout = setTimeout(() => {
-            log('*', '⚠️  Timed out waiting for backend tunnel URL');
-            resolve(null);
-        }, 30000);
-
-        let buffer = '';
-        const handler = (data) => {
-            const text = data.toString();
-            buffer += text;
-            text.split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim()));
-            const url = extractTunnelUrl(buffer);
-            if (url) {
-                clearTimeout(timeout);
-                resolve(url);
+// Kill any processes listening on the given ports (cross-platform)
+function killStaleProcesses(ports) {
+    for (const port of ports) {
+        try {
+            if (IS_WIN) {
+                // Find PIDs listening on the port and kill them
+                const out = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
+                const pids = [...new Set(out.split('\n').map(l => l.trim().split(/\s+/).pop()).filter(p => p && p !== '0'))];
+                for (const pid of pids) {
+                    log('*', `Killing stale process on port ${port} (PID ${pid})`);
+                    try { execSync(`taskkill /PID ${pid} /T /F`, { stdio: 'ignore' }); } catch {}
+                }
+            } else {
+                const out = execSync(`lsof -ti :${port}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
+                const pids = out.trim().split('\n').filter(Boolean);
+                for (const pid of pids) {
+                    log('*', `Killing stale process on port ${port} (PID ${pid})`);
+                    try { execSync(`kill -9 ${pid}`, { stdio: 'ignore' }); } catch {}
+                }
             }
-        };
-        tunBe.stdout?.on('data', handler);
-        tunBe.stderr?.on('data', handler);
-    });
-
-    if (!beUrl) {
-        log('*', '❌ Failed to get backend tunnel URL');
-        process.exit(1);
+        } catch { /* No process on this port — normal */ }
     }
+}
 
-    log('*', `✅ Backend tunnel: ${beUrl}`);
-
-    // Step 3: Build frontend with backend URL injected
+// Build frontend (production)
+function buildFrontend(extraEnv = {}) {
+    const buildEnv = { ...process.env, BACKEND_PORT: String(BE_PORT), ...extraEnv };
     progress('Building frontend...');
     log('*', 'Building frontend (production)...');
-    const buildEnv = { ...process.env, NEXT_PUBLIC_BACKEND_URL: beUrl, BACKEND_PORT: String(BE_PORT), NEXT_PUBLIC_BACKEND_PORT: String(BE_PORT) };
     try {
         execSync('npx next build', {
             cwd: path.join(__dirname, 'frontend'),
@@ -155,19 +103,155 @@ async function main() {
         });
         log('*', '✅ Frontend build complete');
     } catch (e) {
-        log('*', '❌ Frontend build failed');
+        console.error('\x1b[31m  ❌ Frontend build failed\x1b[0m');
         process.exit(1);
     }
+}
 
-    // Step 4: Start frontend production server
+// Graceful shutdown — kill all spawned processes + port listeners
+function cleanup() {
+    log('*', 'Shutting down...');
+    for (const p of allProcs) { try { p.kill(); } catch {} }
+
+    // Kill anything still on our ports
+    if (IS_WIN) {
+        try { execSync(`taskkill /F /FI "IMAGENAME eq cloudflared.exe"`, { stdio: 'ignore' }); } catch {}
+    } else {
+        try { execSync(`pkill -f "cloudflared.*tunnel.*localhost"`, { stdio: 'ignore' }); } catch {}
+    }
+
+    for (const port of [BE_PORT, FE_PORT]) {
+        try {
+            if (IS_WIN) {
+                const out = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] });
+                const pids = [...new Set(out.split('\n').map(l => l.trim().split(/\s+/).pop()).filter(p => p && p !== '0'))];
+                for (const pid of pids) { try { execSync(`taskkill /PID ${pid} /F`, { stdio: 'ignore' }); } catch {} }
+            } else {
+                execSync(`lsof -ti :${port} | xargs kill -9`, { stdio: 'ignore' });
+            }
+        } catch {}
+    }
+
+    console.log('  All processes stopped.');
+    process.exit(0);
+}
+
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+
+// ============================================================
+// LOCAL MODE: build → start backend → start frontend
+// ============================================================
+async function runLocal() {
+    console.log('\n\x1b[1m  🚀 Antigravity Deck — Starting (production)\x1b[0m\n');
+
+    // Kill stale processes
+    killStaleProcesses([BE_PORT, FE_PORT]);
+
+    // Build if needed
+    const nextDir = path.join(__dirname, 'frontend', '.next');
+    if (FORCE_BUILD || !fs.existsSync(nextDir)) {
+        buildFrontend();
+    } else {
+        log('*', '✅ Frontend already built (use --build to force rebuild)');
+    }
+
+    // Start backend
+    progress('Starting backend...');
+    log('*', `Starting backend on port ${BE_PORT}...`);
+    const be = startProcess('BE', 'node', ['server.js'], {
+        cwd: __dirname,
+        env: { ...process.env, PORT: String(BE_PORT), NODE_ENV: 'production' }
+    });
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    // Start frontend
     progress('Starting frontend...');
     log('*', `Starting frontend on port ${FE_PORT}...`);
     const fe = startProcess('FE', 'npx', ['next', 'start', '--port', String(FE_PORT)], {
         cwd: path.join(__dirname, 'frontend'),
-        env: buildEnv
+        env: { ...process.env, BACKEND_PORT: String(BE_PORT), NODE_ENV: 'production' }
+    });
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    if (QUIET) process.stdout.write('\r\x1b[K');
+
+    console.log('\n' + '='.repeat(60));
+    console.log('\x1b[1m\x1b[32m  ✅ READY!\x1b[0m');
+    console.log('='.repeat(60));
+    console.log(`  Backend:  http://localhost:${BE_PORT}`);
+    console.log(`  Frontend: http://localhost:${FE_PORT}`);
+    console.log('='.repeat(60));
+    console.log('\n  Press Ctrl+C to stop\n');
+}
+
+// ============================================================
+// TUNNEL MODE: backend → tunnel → build (with URL) → frontend → tunnel
+// ============================================================
+async function runTunnel() {
+    if (!CLOUDFLARED) {
+        console.log('\n\x1b[31m  ❌ cloudflared not found!\x1b[0m');
+        const installCmd = IS_MAC ? 'brew install cloudflared' : 'winget install cloudflare.cloudflared';
+        console.log(`  Install: ${installCmd}\n`);
+        process.exit(1);
+    }
+    log('*', `Using cloudflared: ${CLOUDFLARED}`);
+
+    // Kill stale processes
+    killStaleProcesses([BE_PORT, FE_PORT]);
+
+    const crypto = require('crypto');
+    const authKey = process.env.AUTH_KEY || crypto.randomBytes(16).toString('hex');
+
+    if (!QUIET) {
+        console.log('\n\x1b[1m  🚀 Antigravity Deck — Starting with Cloudflare Tunnel\x1b[0m');
+        console.log(`  🔑 Auth Key: \x1b[33m${authKey}\x1b[0m\n`);
+    }
+
+    // Step 1: Start backend
+    progress('Starting backend...');
+    log('*', `Starting backend on port ${BE_PORT}...`);
+    const be = startProcess('BE', 'node', ['server.js'], {
+        cwd: __dirname,
+        env: { ...process.env, PORT: String(BE_PORT), AUTH_KEY: authKey, QUIET_POLL: '1', NODE_ENV: 'production' }
+    });
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // Step 2: Start backend tunnel
+    progress('Starting backend tunnel...');
+    log('*', 'Starting Cloudflare tunnel for backend...');
+    const tunBe = spawn(CLOUDFLARED, ['tunnel', '--url', `http://localhost:${BE_PORT}`], {
+        stdio: ['ignore', 'pipe', 'pipe'], shell: true
+    });
+    allProcs.push(tunBe);
+
+    beUrl = await new Promise((resolve) => {
+        const timeout = setTimeout(() => { log('*', '⚠️  Timed out waiting for backend tunnel URL'); resolve(null); }, 30000);
+        let buffer = '';
+        const handler = (data) => {
+            const text = data.toString();
+            buffer += text;
+            text.split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim()));
+            const url = extractTunnelUrl(buffer);
+            if (url) { clearTimeout(timeout); resolve(url); }
+        };
+        tunBe.stdout?.on('data', handler);
+        tunBe.stderr?.on('data', handler);
     });
 
-    // Wait for frontend to be ready
+    if (!beUrl) { log('*', '❌ Failed to get backend tunnel URL'); process.exit(1); }
+    log('*', `✅ Backend tunnel: ${beUrl}`);
+
+    // Step 3: Build frontend (always — needs NEXT_PUBLIC_BACKEND_URL baked in)
+    buildFrontend({ NEXT_PUBLIC_BACKEND_URL: beUrl, NEXT_PUBLIC_BACKEND_PORT: String(BE_PORT) });
+
+    // Step 4: Start frontend
+    progress('Starting frontend...');
+    log('*', `Starting frontend on port ${FE_PORT}...`);
+    const fe = startProcess('FE', 'npx', ['next', 'start', '--port', String(FE_PORT)], {
+        cwd: path.join(__dirname, 'frontend'),
+        env: { ...process.env, NEXT_PUBLIC_BACKEND_URL: beUrl, BACKEND_PORT: String(BE_PORT), NODE_ENV: 'production' }
+    });
     await new Promise(resolve => setTimeout(resolve, 3000));
 
     // Step 5: Start frontend tunnel
@@ -176,33 +260,23 @@ async function main() {
     const tunFe = spawn(CLOUDFLARED, ['tunnel', '--url', `http://localhost:${FE_PORT}`], {
         stdio: ['ignore', 'pipe', 'pipe'], shell: true
     });
+    allProcs.push(tunFe);
 
-    // Capture frontend tunnel URL
     feUrl = await new Promise((resolve) => {
-        const timeout = setTimeout(() => {
-            log('*', '⚠️  Timed out waiting for frontend tunnel URL');
-            resolve(null);
-        }, 30000);
-
+        const timeout = setTimeout(() => { log('*', '⚠️  Timed out waiting for frontend tunnel URL'); resolve(null); }, 30000);
         let buffer = '';
         const handler = (data) => {
             const text = data.toString();
             buffer += text;
             text.split('\n').filter(l => l.trim()).forEach(l => log('TUN-FE', l.trim()));
             const url = extractTunnelUrl(buffer);
-            if (url) {
-                clearTimeout(timeout);
-                resolve(url);
-            }
+            if (url) { clearTimeout(timeout); resolve(url); }
         };
         tunFe.stdout?.on('data', handler);
         tunFe.stderr?.on('data', handler);
     });
 
-    // Build the auto-auth URL with key embedded
     const qrUrl = feUrl ? `${feUrl}?key=${authKey}` : null;
-
-    // Clear the progress line before showing final output
     if (QUIET) process.stdout.write('\r\x1b[K');
 
     if (feUrl) {
@@ -215,12 +289,10 @@ async function main() {
         console.log(`  Local:       http://localhost:${FE_PORT}`);
         console.log('='.repeat(60));
 
-        // Print QR code — scan to open with auto-auth
         console.log('\n\x1b[1m  📱 Scan this QR code to open (auto-login):\x1b[0m\n');
         try {
             const qrcode = require('qrcode-terminal');
             qrcode.generate(qrUrl, { small: true }, (qr) => {
-                // Indent each line for nicer display
                 console.log(qr.split('\n').map(l => '    ' + l).join('\n'));
                 console.log(`\n  🔗 ${qrUrl}\n`);
             });
@@ -233,7 +305,7 @@ async function main() {
         console.log(`  Local: http://localhost:${FE_PORT}`);
     }
 
-    // Write tunnel info to file (readable even when terminal is garbled)
+    // Write tunnel info file
     const infoFile = path.join(__dirname, '.tunnel-info.txt');
     const info = [
         `Frontend: ${feUrl || 'FAILED'}`,
@@ -247,7 +319,7 @@ async function main() {
     fs.writeFileSync(infoFile, info);
     log('*', `Tunnel info written to ${infoFile}`);
 
-    // Keep remaining output flowing (suppressed in quiet mode)
+    // Keep remaining output flowing
     if (!QUIET) {
         tunBe.stdout?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim())));
         tunBe.stderr?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim())));
@@ -255,14 +327,8 @@ async function main() {
         tunFe.stderr?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-FE', l.trim())));
     }
 
-    // Graceful shutdown
-    const cleanup = () => {
-        log('*', 'Shutting down...');
-        [be, fe, tunBe, tunFe].forEach(p => { try { p.kill(); } catch { } });
-        process.exit(0);
-    };
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
+    console.log('\n  Press Ctrl+C to stop\n');
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+// === Entry point ===
+(LOCAL_MODE ? runLocal() : runTunnel()).catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
- start-tunnel.js now supports --local flag (no tunnels)
- Ports 9807/9808 defined only in start-tunnel.js
- Setup scripts simplified: clone → deps → call start-tunnel.js
- Cross-platform port kill in Node.js
- package.json 'prod' script uses start-tunnel.js --local
- Removed ~200 lines of duplicated code from setup scripts