### PR TITLE
feat: auto-populate defaultWorkspaceRoot for new users

### DIFF
--- a/settings.sample.json
+++ b/settings.sample.json
@@ -1,5 +1,4 @@
 {
     "autoAccept": false,
-    "defaultWorkspaceRoot": "",
     "defaultModel": ""
-}
+}

--- a/src/auto-accept.js
+++ b/src/auto-accept.js
@@ -58,6 +58,18 @@ function validateFilePathInWorkspace(filePath) {
             }
         }
     }
+
+    // Fallback: include defaultWorkspaceRoot from settings
+    // (ensures validation works even before LS instances are detected)
+    const settings = getSettings();
+    if (settings.defaultWorkspaceRoot) {
+        try {
+            allowedRoots.push(fs.realpathSync(settings.defaultWorkspaceRoot));
+        } catch {
+            // Default root doesn't exist yet — add lexically
+            allowedRoots.push(path.resolve(settings.defaultWorkspaceRoot));
+        }
+    }
     
     if (allowedRoots.length === 0) {
         // No workspaces available - reject for safety

--- a/src/config.js
+++ b/src/config.js
@@ -43,6 +43,14 @@ function loadSettings() {
     } catch {
         _settings = { ...DEFAULT_SETTINGS };
     }
+
+    // Auto-populate defaultWorkspaceRoot if empty/missing (new user onboarding)
+    if (!_settings.defaultWorkspaceRoot) {
+        _settings.defaultWorkspaceRoot = DEFAULT_SETTINGS.defaultWorkspaceRoot;
+        console.log(`[*] Auto-set defaultWorkspaceRoot: ${_settings.defaultWorkspaceRoot}`);
+        try { fs.writeFileSync(SETTINGS_PATH, JSON.stringify(_settings, null, 2), 'utf-8'); } catch { }
+    }
+
     return _settings;
 }
 


### PR DESCRIPTION
- config.js: if defaultWorkspaceRoot is empty after loading settings, auto-fill with ~/AntigravityWorkspaces and persist to disk
- auto-accept.js: add defaultWorkspaceRoot as fallback allowed root in validateFilePathInWorkspace() so validation works before LS starts
- settings.sample.json: removed empty defaultWorkspaceRoot override so code default takes effect naturally