### PR TITLE
feat: default workspace auto-config + setup.ps1 fix

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -116,16 +116,26 @@ if (Test-Path "$DIR\.git") {
             $behind = (git rev-list --count "HEAD..origin/main" 2>$null)
             Write-Host "  [i] $behind new commit(s) available -- pulling..." -ForegroundColor Yellow
 
+            $ErrorActionPreference = "Continue"
             git pull --ff-only 2>$null
+            $ErrorActionPreference = "Stop"
 
             $hashAfter = (git rev-parse HEAD 2>$null)
 
             # List changed files between old and new
-            $updatedFiles = @(git diff --name-only $hashBefore $hashAfter 2>$null)
+            try {
+                $updatedFiles = @(git diff --name-only $hashBefore $hashAfter 2>$null)
+            } catch {
+                $updatedFiles = @()
+            }
             $scenario = "updated"
 
-            $shortNewHash = $hashAfter.Substring(0, 7)
-            Write-Host "  [OK] Updated to $shortNewHash" -ForegroundColor Green
+            if ($hashAfter) {
+                $shortNewHash = $hashAfter.Substring(0, 7)
+                Write-Host "  [OK] Updated to $shortNewHash" -ForegroundColor Green
+            } else {
+                Write-Host "  [OK] Updated successfully" -ForegroundColor Green
+            }
         }
     }
     catch {


### PR DESCRIPTION
## Changes\n\n### 1. Auto-populate defaultWorkspaceRoot (new user onboarding)\n- **config.js**: If defaultWorkspaceRoot is empty after loading settings, auto-set to ~/AntigravityWorkspaces and persist\n- **auto-accept.js**: Add defaultWorkspaceRoot as fallback allowed root in alidateFilePathInWorkspace() so validation works before LS starts\n- **settings.sample.json**: Removed empty defaultWorkspaceRoot override\n\n### 2. Fix setup.ps1 false offline warning\n- ErrorActionPreference=Stop was catching benign git stderr (LF warnings) after successful pull\n- Wrapped git pull with ErrorActionPreference=Continue\n- Guarded git diff and .Substring() calls