### PR TITLE
feat: Live Logs — capture all FE/BE errors with full context

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -30,6 +30,7 @@ import { SourceControlView } from '@/components/source-control-view';
 import { ResourceMonitorView } from '@/components/resource-monitor-view';
 import { WorkspaceOnboardModal } from '@/components/workspace-onboard-modal';
 import { notificationService } from '@/lib/notifications';
+import { initAppLogger } from '@/lib/app-logger';
 import { usePwaInstall } from '@/hooks/use-pwa-install';
 import { getSettings } from '@/lib/cascade-api';
 
@@ -104,9 +105,10 @@ export default function Home() {
   });
   const [showShortcuts, setShowShortcuts] = useState(false);
 
-  // === PWA Notification service init ===
+  // === PWA Notification service init + App Logger ===
   useEffect(() => {
     notificationService?.init();
+    initAppLogger();
   }, []);
 
   // === PWA Install ===

--- a/frontend/components/agent-logs-view.tsx
+++ b/frontend/components/agent-logs-view.tsx
@@ -7,6 +7,7 @@ import {
     Activity, User, Bot, Wrench, Filter, Trash2,
     Wifi, WifiOff, ChevronDown, ChevronRight,
     Terminal, FileCode2, Search, Eye, Globe, Copy, Check,
+    AlertTriangle, Bug, Info, Server, Monitor,
 } from 'lucide-react';
 
 // ─── Step type classification ─────────────────────────────────────────────────
@@ -89,6 +90,11 @@ interface LogEvent {
     stepLabel?: string;
     stepContent?: string;
     stepIndex?: number;
+    // For app_log events
+    logLevel?: 'info' | 'warn' | 'error';
+    logSource?: 'frontend' | 'backend';
+    logModule?: string;
+    logStack?: string;
 }
 
 // ─── Extract readable content from a step ────────────────────────────────────
@@ -139,11 +145,133 @@ function extractContent(step: any, type: string): string {
     return '';
 }
 
-// ─── Log Item component ───────────────────────────────────────────────────────
+// ─── Log Level config ─────────────────────────────────────────────────────────
+
+const LOG_LEVEL_CONFIG: Record<string, { icon: React.ElementType; color: string; bg: string; border: string }> = {
+    error: { icon: Bug, color: 'text-red-400', bg: 'bg-red-400/8', border: 'border-red-400/20' },
+    warn: { icon: AlertTriangle, color: 'text-amber-400', bg: 'bg-amber-400/8', border: 'border-amber-400/20' },
+    info: { icon: Info, color: 'text-sky-400', bg: 'bg-sky-400/5', border: 'border-sky-400/15' },
+};
+
+const SOURCE_CONFIG: Record<string, { icon: React.ElementType; label: string; color: string }> = {
+    backend: { icon: Server, label: 'BE', color: 'text-violet-400' },
+    frontend: { icon: Monitor, label: 'FE', color: 'text-cyan-400' },
+};
+
+// ─── App Log Item component ──────────────────────────────────────────────────
+
+const AppLogItem = memo(function AppLogItem({ event }: { event: LogEvent }) {
+    const [expanded, setExpanded] = useState(false);
+    const [copied, setCopied] = useState(false);
+
+    const levelCfg = LOG_LEVEL_CONFIG[event.logLevel || 'info'] || LOG_LEVEL_CONFIG.info;
+    const srcCfg = SOURCE_CONFIG[event.logSource || 'backend'] || SOURCE_CONFIG.backend;
+    const LevelIcon = levelCfg.icon;
+    const time = new Date(event.ts).toLocaleTimeString('vi-VN', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    const hasStack = !!event.logStack;
+    const hasContext = event.payload?.context && Object.keys(event.payload.context).length > 0;
+    const hasDetail = hasStack || hasContext;
+    const message = event.stepContent || '';
+    const preview = message.length > 200 ? message.slice(0, 200) + '…' : message;
+
+    const copyAll = () => {
+        const text = [
+            `[${event.logLevel?.toUpperCase()}] [${event.logSource}/${event.logModule}]`,
+            message,
+            event.logStack ? `\nStack:\n${event.logStack}` : '',
+            hasContext ? `\nContext:\n${JSON.stringify(event.payload?.context, null, 2)}` : '',
+        ].filter(Boolean).join('\n');
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+    };
+
+    return (
+        <div className={cn('group border-b transition-colors hover:bg-muted/10', levelCfg.bg, levelCfg.border, 'border-l-2')}>
+            <div
+                className="flex items-start gap-2.5 px-3 py-1.5 cursor-pointer"
+                onClick={() => hasDetail && setExpanded(e => !e)}
+            >
+                {/* Level icon */}
+                <div className="flex flex-col items-center gap-1 pt-0.5 shrink-0">
+                    <LevelIcon className={cn('w-3.5 h-3.5', levelCfg.color)} />
+                </div>
+
+                {/* Content */}
+                <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                        {/* Source badge */}
+                        <span className={cn(
+                            'text-[9px] font-bold tracking-wider px-1.5 py-0.5 rounded',
+                            event.logSource === 'frontend' ? 'bg-cyan-400/10 text-cyan-400' : 'bg-violet-400/10 text-violet-400'
+                        )}>
+                            {srcCfg.label}
+                        </span>
+                        {/* Module name */}
+                        {event.logModule && event.logModule !== 'unknown' && (
+                            <span className="text-[9px] text-muted-foreground/50 font-mono">{event.logModule}</span>
+                        )}
+                        <span className="ml-auto text-[9px] text-muted-foreground/25 font-mono shrink-0">{time}</span>
+                        {hasDetail && (
+                            <span className="text-muted-foreground/30">
+                                {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                            </span>
+                        )}
+                    </div>
+                    {preview && (
+                        <p className={cn('text-xs mt-0.5 break-words leading-relaxed line-clamp-3',
+                            event.logLevel === 'error' ? 'text-red-300/80' : event.logLevel === 'warn' ? 'text-amber-300/70' : 'text-foreground/50'
+                        )}>
+                            {preview}
+                        </p>
+                    )}
+                </div>
+
+                {/* Copy button */}
+                <button
+                    onClick={(e) => { e.stopPropagation(); copyAll(); }}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 p-1 rounded hover:bg-muted/30"
+                    title="Copy full log entry"
+                >
+                    {copied ? <Check className="w-3 h-3 text-emerald-400" /> : <Copy className="w-3 h-3 text-muted-foreground/40" />}
+                </button>
+            </div>
+
+            {/* Expanded: stack trace + context */}
+            {expanded && (
+                <div className="mx-3 mb-2 space-y-1">
+                    {event.logStack && (
+                        <div className={cn('rounded border overflow-auto max-h-40', levelCfg.border)}>
+                            <pre className={cn('text-[10px] font-mono p-2 whitespace-pre-wrap break-all leading-relaxed',
+                                event.logLevel === 'error' ? 'text-red-300/60' : 'text-foreground/40'
+                            )}>
+                                {event.logStack}
+                            </pre>
+                        </div>
+                    )}
+                    {hasContext && (
+                        <div className="rounded border border-border/15 overflow-auto max-h-32">
+                            <pre className="text-[10px] font-mono text-foreground/40 p-2 whitespace-pre-wrap break-all leading-relaxed">
+                                {JSON.stringify(event.payload?.context, null, 2)}
+                            </pre>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+});
+
+// ─── Step Log Item component ─────────────────────────────────────────────────
 
 const LogItem = memo(function LogItem({ event }: { event: LogEvent }) {
     const [expanded, setExpanded] = useState(false);
     const [copied, setCopied] = useState(false);
+
+    // Render app_log events with the dedicated component
+    if (event.type === 'app_log') {
+        return <AppLogItem event={event} />;
+    }
 
     if (event.type === 'cascade_status') {
         const status = event.payload?.status || '';
@@ -243,10 +371,12 @@ const LogItem = memo(function LogItem({ event }: { event: LogEvent }) {
 
 // ─── Filter pill ─────────────────────────────────────────────────────────────
 
-type FilterMode = 'all' | 'user' | 'agent' | 'tool';
+type FilterMode = 'all' | 'user' | 'agent' | 'tool' | 'errors' | 'logs';
 
-const FILTERS: { mode: FilterMode; label: string }[] = [
+const FILTERS: { mode: FilterMode; label: string; icon?: React.ElementType }[] = [
     { mode: 'all', label: 'All' },
+    { mode: 'errors', label: 'Errors', icon: Bug },
+    { mode: 'logs', label: 'Logs', icon: Terminal },
     { mode: 'user', label: 'User' },
     { mode: 'agent', label: 'Agent' },
     { mode: 'tool', label: 'Tools' },
@@ -284,7 +414,19 @@ export function AgentLogsView() {
         const offAll = wsService.onAll((data) => {
             const convId = (data.conversationId as string) || (data.cascadeId as string) || '';
 
-            if (data.type === 'cascade_status') {
+            if (data.type === 'app_log') {
+                // App log event from FE or BE
+                addEvent({
+                    type: 'app_log',
+                    convId: '',
+                    stepContent: (data.message as string) || '',
+                    logLevel: (data.level as 'info' | 'warn' | 'error') || 'info',
+                    logSource: (data.source as 'frontend' | 'backend') || 'backend',
+                    logModule: (data.module as string) || 'unknown',
+                    logStack: (data.stack as string) || undefined,
+                    payload: data,
+                });
+            } else if (data.type === 'cascade_status') {
                 addEvent({ type: 'cascade_status', convId, payload: data });
             } else if (data.type === 'conversations_updated') {
                 addEvent({ type: 'conversations_updated', convId: '', payload: data });
@@ -342,12 +484,20 @@ export function AgentLogsView() {
 
     const filtered = filter === 'all'
         ? events
-        : events.filter(e =>
-            (filter === 'user' && e.stepRole === 'user') ||
-            (filter === 'agent' && e.stepRole === 'agent') ||
-            (filter === 'tool' && e.stepRole === 'tool') ||
-            e.type === 'cascade_status'
-        );
+        : events.filter(e => {
+            if (filter === 'errors') return e.type === 'app_log' && (e.logLevel === 'error' || e.logLevel === 'warn');
+            if (filter === 'logs') return e.type === 'app_log';
+            return (
+                (filter === 'user' && e.stepRole === 'user') ||
+                (filter === 'agent' && e.stepRole === 'agent') ||
+                (filter === 'tool' && e.stepRole === 'tool') ||
+                e.type === 'cascade_status'
+            );
+        });
+
+    // Count errors/warnings for badge
+    const errorCount = events.filter(e => e.type === 'app_log' && e.logLevel === 'error').length;
+    const warnCount = events.filter(e => e.type === 'app_log' && e.logLevel === 'warn').length;
 
     return (
         <div className="flex flex-col h-full bg-background">
@@ -374,6 +524,16 @@ export function AgentLogsView() {
                     </span>
                     {events.length > 0 && (
                         <span className="text-[9px] text-muted-foreground/30 font-mono">{events.length}</span>
+                    )}
+                    {errorCount > 0 && (
+                        <span className="flex items-center gap-0.5 text-[9px] font-mono px-1.5 py-0.5 rounded-full bg-red-400/10 text-red-400 border border-red-400/20">
+                            <Bug className="w-2.5 h-2.5" />{errorCount}
+                        </span>
+                    )}
+                    {warnCount > 0 && (
+                        <span className="flex items-center gap-0.5 text-[9px] font-mono px-1.5 py-0.5 rounded-full bg-amber-400/10 text-amber-400 border border-amber-400/20">
+                            <AlertTriangle className="w-2.5 h-2.5" />{warnCount}
+                        </span>
                     )}
                 </div>
 

--- a/frontend/lib/app-logger.ts
+++ b/frontend/lib/app-logger.ts
@@ -1,0 +1,141 @@
+/**
+ * Frontend App Logger
+ * Captures console.error, console.warn, window.onerror, and unhandled rejections
+ * and sends them to the backend via WebSocket as app_log events.
+ * Import once in a root layout/provider — interception starts immediately.
+ */
+'use client';
+
+import { wsService } from './ws-service';
+
+type LogLevel = 'info' | 'warn' | 'error';
+
+interface AppLogEntry {
+    type: 'app_log';
+    level: LogLevel;
+    source: 'frontend';
+    module: string;
+    message: string;
+    stack?: string;
+    context?: Record<string, unknown>;
+    ts: number;
+}
+
+// Throttle to avoid flooding
+const _seen = new Map<string, number>();
+const THROTTLE_MS = 1000;
+
+function shouldThrottle(msg: string): boolean {
+    const key = msg.slice(0, 120);
+    const now = Date.now();
+    const last = _seen.get(key);
+    if (last && now - last < THROTTLE_MS) return true;
+    _seen.set(key, now);
+    if (_seen.size > 100) {
+        for (const [k, v] of _seen) {
+            if (now - v > 10000) _seen.delete(k);
+        }
+    }
+    return false;
+}
+
+function send(entry: AppLogEntry) {
+    if (shouldThrottle(entry.message)) return;
+    wsService?.send(entry as unknown as Record<string, unknown>);
+}
+
+function formatArgs(args: unknown[]): string {
+    return args.map(a => {
+        if (a instanceof Error) return `${a.message}\n${a.stack || ''}`;
+        if (typeof a === 'object' && a !== null) {
+            try { return JSON.stringify(a); }
+            catch { return String(a); }
+        }
+        return String(a);
+    }).join(' ');
+}
+
+// === Monkey-patch console.error and console.warn ===
+let _patched = false;
+
+export function initAppLogger() {
+    if (_patched || typeof window === 'undefined') return;
+    _patched = true;
+
+    const origError = console.error.bind(console);
+    const origWarn = console.warn.bind(console);
+
+    console.error = function (...args: unknown[]) {
+        origError(...args);
+        const msg = formatArgs(args);
+        const stack = (args.find(a => a instanceof Error) as Error | undefined)?.stack;
+        send({
+            type: 'app_log',
+            level: 'error',
+            source: 'frontend',
+            module: extractModule(stack),
+            message: msg.slice(0, 2000),
+            stack: stack?.slice(0, 3000),
+            ts: Date.now(),
+        });
+    };
+
+    console.warn = function (...args: unknown[]) {
+        origWarn(...args);
+        const msg = formatArgs(args);
+        send({
+            type: 'app_log',
+            level: 'warn',
+            source: 'frontend',
+            module: extractModule(),
+            message: msg.slice(0, 2000),
+            ts: Date.now(),
+        });
+    };
+
+    // === Global error handlers ===
+    window.addEventListener('error', (event) => {
+        send({
+            type: 'app_log',
+            level: 'error',
+            source: 'frontend',
+            module: extractModuleFromFilename(event.filename),
+            message: event.message || 'Unknown error',
+            stack: `at ${event.filename}:${event.lineno}:${event.colno}`,
+            context: { lineno: event.lineno, colno: event.colno, filename: event.filename },
+            ts: Date.now(),
+        });
+    });
+
+    window.addEventListener('unhandledrejection', (event) => {
+        const reason = event.reason;
+        const msg = reason instanceof Error ? reason.message : String(reason);
+        const stack = reason instanceof Error ? reason.stack : undefined;
+        send({
+            type: 'app_log',
+            level: 'error',
+            source: 'frontend',
+            module: 'promise',
+            message: `Unhandled Rejection: ${msg}`.slice(0, 2000),
+            stack: stack?.slice(0, 3000),
+            ts: Date.now(),
+        });
+    });
+}
+
+// Best-effort module name extraction from stack traces
+function extractModule(stack?: string): string {
+    if (!stack) return 'unknown';
+    // Look for component/file names in stack trace lines
+    const match = stack.match(/at\s+(\w[\w.]*)\s+\(/);
+    if (match) return match[1];
+    const fileMatch = stack.match(/\/([\w-]+)\.(tsx?|jsx?)/);
+    if (fileMatch) return fileMatch[1];
+    return 'unknown';
+}
+
+function extractModuleFromFilename(filename?: string | null): string {
+    if (!filename) return 'unknown';
+    const match = filename.match(/\/([\w-]+)\.(tsx?|jsx?)/);
+    return match ? match[1] : 'unknown';
+}

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 // === AntigravityAuto Server — Entry Point ===
+const logger = require('./src/logger'); // MUST be first — intercepts console.* globally
 const express = require('express');
 const http = require('http');
 const crypto = require('crypto');
@@ -224,6 +225,9 @@ if (AUTH_KEY) {
 // Routes & WebSocket
 setupRoutes(app);
 setupWebSocket(wss);
+
+// Connect logger → broadcast app_log events to Live Logs viewers
+logger.connect(require('./src/ws').broadcastToGlobal);
 
 // Start
 server.listen(PORT, async () => {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,176 @@
+// === Centralized Logger Module ===
+// Intercepts console.log/warn/error and broadcasts app_log events via WebSocket.
+// Also captures uncaughtException and unhandledRejection.
+// Usage: require('./logger') early in server.js — interception starts immediately.
+
+const LOG_BUFFER_MAX = 50; // buffer logs until WS is ready
+const _buffer = [];
+let _broadcastFn = null;
+
+// Log levels
+const LEVEL = { info: 'info', warn: 'warn', error: 'error' };
+
+// Extract caller module name from stack trace
+function getCallerModule() {
+    const orig = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, stack) => stack;
+    const err = new Error();
+    const stack = err.stack;
+    Error.prepareStackTrace = orig;
+
+    // Walk up the stack to find the first frame outside logger.js
+    if (Array.isArray(stack)) {
+        for (let i = 0; i < stack.length; i++) {
+            const file = stack[i].getFileName();
+            if (file && !file.includes('logger.js') && !file.includes('node:')) {
+                const path = require('path');
+                return path.basename(file, path.extname(file));
+            }
+        }
+    }
+    return 'unknown';
+}
+
+// Format args to a single string (like console does)
+function formatArgs(args) {
+    return args.map(a => {
+        if (a instanceof Error) return `${a.message}\n${a.stack || ''}`;
+        if (typeof a === 'object') {
+            try { return JSON.stringify(a, null, 2); }
+            catch { return String(a); }
+        }
+        return String(a);
+    }).join(' ');
+}
+
+// Create a log entry
+function createEntry(level, module, message, stack, context) {
+    return {
+        type: 'app_log',
+        level,
+        source: 'backend',
+        module: module || 'unknown',
+        message: typeof message === 'string' ? message.slice(0, 2000) : String(message).slice(0, 2000),
+        stack: stack ? String(stack).slice(0, 3000) : undefined,
+        context: context || undefined,
+        ts: Date.now(),
+    };
+}
+
+// Broadcast or buffer
+function emit(entry) {
+    if (_broadcastFn) {
+        try { _broadcastFn(entry); } catch { /* can't log recursively */ }
+    } else {
+        _buffer.push(entry);
+        if (_buffer.length > LOG_BUFFER_MAX) _buffer.shift();
+    }
+}
+
+// === Monkey-patch console ===
+
+const _origLog = console.log.bind(console);
+const _origWarn = console.warn.bind(console);
+const _origError = console.error.bind(console);
+
+// Throttle: don't broadcast noisy recurring messages
+const _seen = new Map();
+const THROTTLE_MS = 500;
+
+function shouldThrottle(message) {
+    const key = message.slice(0, 100);
+    const now = Date.now();
+    const last = _seen.get(key);
+    if (last && now - last < THROTTLE_MS) return true;
+    _seen.set(key, now);
+    // Clean old entries periodically
+    if (_seen.size > 200) {
+        for (const [k, v] of _seen) {
+            if (now - v > 10000) _seen.delete(k);
+        }
+    }
+    return false;
+}
+
+// Skip internal/noisy prefixes to avoid flooding Live Logs
+const SKIP_PREFIXES = ['[poll]', '[*] Poll rate', '[WS] broadcast steps_new'];
+
+function shouldSkip(msg) {
+    for (const p of SKIP_PREFIXES) {
+        if (msg.startsWith(p)) return true;
+    }
+    return false;
+}
+
+console.log = function (...args) {
+    _origLog(...args);
+    const msg = formatArgs(args);
+    if (!shouldSkip(msg) && !shouldThrottle(msg)) {
+        emit(createEntry(LEVEL.info, getCallerModule(), msg));
+    }
+};
+
+console.warn = function (...args) {
+    _origWarn(...args);
+    const msg = formatArgs(args);
+    if (!shouldThrottle(msg)) {
+        emit(createEntry(LEVEL.warn, getCallerModule(), msg));
+    }
+};
+
+console.error = function (...args) {
+    _origError(...args);
+    const msg = formatArgs(args);
+    const stack = args.find(a => a instanceof Error)?.stack;
+    emit(createEntry(LEVEL.error, getCallerModule(), msg, stack));
+};
+
+// === Uncaught Errors ===
+
+process.on('uncaughtException', (err) => {
+    _origError('[UNCAUGHT]', err);
+    emit(createEntry(LEVEL.error, 'process', `Uncaught Exception: ${err.message}`, err.stack, { fatal: true }));
+});
+
+process.on('unhandledRejection', (reason) => {
+    const msg = reason instanceof Error ? reason.message : String(reason);
+    const stack = reason instanceof Error ? reason.stack : undefined;
+    _origError('[UNHANDLED_REJECTION]', reason);
+    emit(createEntry(LEVEL.error, 'process', `Unhandled Rejection: ${msg}`, stack, { fatal: false }));
+});
+
+// === Public API ===
+
+/**
+ * Connect the logger to WebSocket broadcast.
+ * Call after WS is set up: logger.connect(require('./ws').broadcastToGlobal);
+ */
+function connect(broadcastFn) {
+    _broadcastFn = broadcastFn;
+    // Flush buffered entries
+    while (_buffer.length > 0) {
+        const entry = _buffer.shift();
+        try { _broadcastFn(entry); } catch { break; }
+    }
+}
+
+/**
+ * Manually log with full context (for use in catch blocks that want explicit module info).
+ * logger.error('routes', 'Failed to create workspace', err, { path: '/api/workspaces' });
+ */
+function error(module, message, err, context) {
+    _origError(`[${module}]`, message, err?.message || '');
+    emit(createEntry(LEVEL.error, module, message + (err?.message ? `: ${err.message}` : ''), err?.stack, context));
+}
+
+function warn(module, message, context) {
+    _origWarn(`[${module}]`, message);
+    emit(createEntry(LEVEL.warn, module, message, undefined, context));
+}
+
+function info(module, message, context) {
+    _origLog(`[${module}]`, message);
+    emit(createEntry(LEVEL.info, module, message, undefined, context));
+}
+
+module.exports = { connect, error, warn, info };

--- a/src/ws.js
+++ b/src/ws.js
@@ -46,6 +46,9 @@ function setupWebSocket(wss, { ensureCached, stepCache }) {
                     // Live Logs mode: receive all broadcasts regardless of conversation
                     globalViewers.add(ws);
                     console.log(`[WS] subscribe_all — global viewers: ${globalViewers.size}`);
+                } else if (msg.type === 'app_log') {
+                    // Frontend error/log forwarding — rebroadcast to all Live Logs viewers
+                    broadcastToGlobal({ ...msg, ts: msg.ts || Date.now() });
                 }
             } catch (e) { }
         });
@@ -86,4 +89,12 @@ function broadcastAll(data) {
     });
 }
 
-module.exports = { setupWebSocket, sendToOne, broadcast, broadcastAll };
+// Broadcast to global viewers only (Live Logs subscribers — for app_log events)
+function broadcastToGlobal(data) {
+    const msg = JSON.stringify(data);
+    globalViewers.forEach(v => {
+        if (v.readyState === 1) v.send(msg);
+    });
+}
+
+module.exports = { setupWebSocket, sendToOne, broadcast, broadcastAll, broadcastToGlobal };


### PR DESCRIPTION
## What Changed

Enhanced Live Logs to capture **all** console.log/warn/error, try/catch errors, and uncaught exceptions from both frontend and backend — with full stack traces, module names, and severity levels.

### New Files
- **src/logger.js** — Backend centralized logger (monkey-patches console.*, captures uncaughtException/unhandledRejection)
- **frontend/lib/app-logger.ts** — Frontend error capture (console.error/warn, window.onerror, unhandledrejection)

### Modified Files  
- **src/ws.js** — Added broadcastToGlobal() + FE→BE app_log forwarding
- **server.js** — Integrated logger at startup
- **frontend/app/page.tsx** — Initialize FE logger
- **frontend/components/agent-logs-view.tsx** — New AppLogItem component with severity colors, source badges, stack trace expansion, error/warn count badges, Errors/Logs filter tabs

### Data Flow
FE errors → wsService.send → BE ws.js → broadcastToGlobal → Live Logs UI
BE errors → logger.js intercepts console.* → broadcastToGlobal → Live Logs UI