### PR TITLE
fix: broadcast conversations_updated on cascade completion

### DIFF
--- a/frontend/lib/websocket.ts
+++ b/frontend/lib/websocket.ts
@@ -194,7 +194,15 @@ export function useWebSocket() {
         const offCascadeStatus = wsService.on('cascade_status', (data) => {
             setState(prev => {
                 if (data.conversationId && data.conversationId !== prev.currentConvId) return prev;
-                return { ...prev, cascadeStatus: data.status as string };
+                const newState = { ...prev, cascadeStatus: data.status as string };
+                // When cascade completes, bump conversationsVersion to refresh sidebar
+                // (summary/title/stepCount may have changed)
+                const isDone = data.status !== 'CASCADE_RUN_STATUS_RUNNING' &&
+                               data.status !== 'CASCADE_RUN_STATUS_WAITING_FOR_USER';
+                if (isDone && prev.cascadeStatus && prev.cascadeStatus !== data.status) {
+                    newState.conversationsVersion = prev.conversationsVersion + 1;
+                }
+                return newState;
             });
         });
 

--- a/src/poller.js
+++ b/src/poller.js
@@ -142,6 +142,8 @@ async function pollNow() {
                     triggerBridgeRelay(cascadeId);
                     // Final poll: fetch complete step content before stopping
                     await pollConversation(cascadeId, info);
+                    // Notify frontend to refresh conversation list (summary/title may have changed)
+                    _broadcastAll({ type: 'conversations_updated' });
                 }
 
                 // Fast-cascade relay: first time seeing this cascade and it's already IDLE/DONE


### PR DESCRIPTION
## Problem
Sidebar không update conversation summary/title/stepCount sau khi agent trả lời xong.

## Root Cause
- `conversations_updated` event chỉ broadcast khi phát hiện conversation MỚI, không broadcast khi cascade hoàn thành
- Sidebar phụ thuộc hoàn toàn vào event này để refresh

## Fix
- **Backend (poller.js)**: broadcast `conversations_updated` khi cascade chuyển RUNNING/WAITING → IDLE/DONE
- **Frontend (websocket.ts)**: bump `conversationsVersion` khi nhận `cascade_status` DONE (backup trigger)

## Testing
- Frontend build ✅ pass (0 TS errors)
- 2 files changed, 11 insertions, 1 deletion