### PR TITLE
fix: re-sync step content on conversations_updated

### DIFF
--- a/frontend/lib/websocket.ts
+++ b/frontend/lib/websocket.ts
@@ -207,8 +207,16 @@ export function useWebSocket() {
         });
 
         const offConvUpdated = wsService.on('conversations_updated', () => {
-            console.log('[WS] conversations_updated — refreshing sidebar');
-            setState(prev => ({ ...prev, conversationsVersion: prev.conversationsVersion + 1 }));
+            console.log('[WS] conversations_updated — refreshing sidebar + step content');
+            setState(prev => {
+                // Re-sync step content: re-send set_conversation to get fresh steps_init
+                // with finalized step data from backend cache
+                const convId = prev.currentConvId;
+                if (convId) {
+                    wsService?.send({ type: 'set_conversation', conversationId: convId });
+                }
+                return { ...prev, conversationsVersion: prev.conversationsVersion + 1 };
+            });
         });
 
         const offResources = wsService.on('workspace_resources', (data) => {


### PR DESCRIPTION
On every `conversations_updated` event from backend post-completion polls, frontend re-sends `set_conversation` to get fresh `steps_init` with finalized step content. This ensures the last step's content is fully updated after agent responds.
