### PR TITLE
feat: add uninstall scripts with auto process kill

### DIFF
--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,0 +1,111 @@
+# === Antigravity Deck -- Uninstall (Windows PowerShell) ===
+# Usage: irm https://raw.githubusercontent.com/tysonnbt/Antigravity-Deck/main/scripts/uninstall.ps1 | iex
+
+$ErrorActionPreference = "SilentlyContinue"
+$INSTALL_DIR = Join-Path $env:LOCALAPPDATA "AntigravityDeck"
+
+Write-Host ""
+Write-Host "  Antigravity Deck -- Uninstall" -ForegroundColor Cyan
+Write-Host "  ==============================" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "  Install location: $INSTALL_DIR" -ForegroundColor DarkGray
+Write-Host ""
+
+if (-not (Test-Path $INSTALL_DIR)) {
+    Write-Host "  [i] Nothing to uninstall — directory not found." -ForegroundColor Yellow
+    Write-Host ""
+    exit 0
+}
+
+# --- Kill processes with open handles inside the install dir ---
+Write-Host "  [i] Checking for running processes..." -ForegroundColor Cyan
+
+$killed = @()
+
+# Method 1: Find node/antigravity processes whose command line references the install dir
+$procs = Get-WmiObject Win32_Process -Filter "Name = 'node.exe'" 2>$null
+foreach ($proc in $procs) {
+    try {
+        $cmdLine = $proc.CommandLine
+        if ($cmdLine -and $cmdLine -like "*$INSTALL_DIR*") {
+            Stop-Process -Id $proc.ProcessId -Force 2>$null
+            $killed += $proc.ProcessId
+            Write-Host "  [OK] Killed node.exe (PID $($proc.ProcessId))" -ForegroundColor Green
+        }
+    } catch { }
+}
+
+# Method 2: Also catch any child processes started from that dir
+$allProcs = @("node.exe", "next-server.exe", "cloudflared.exe")
+foreach ($procName in $allProcs) {
+    $procs2 = Get-WmiObject Win32_Process -Filter "Name = '$procName'" 2>$null
+    foreach ($proc in $procs2) {
+        try {
+            $cmdLine = $proc.CommandLine
+            if ($cmdLine -and $cmdLine -like "*AntigravityDeck*") {
+                if ($killed -notcontains $proc.ProcessId) {
+                    Stop-Process -Id $proc.ProcessId -Force 2>$null
+                    $killed += $proc.ProcessId
+                    Write-Host "  [OK] Killed $procName (PID $($proc.ProcessId))" -ForegroundColor Green
+                }
+            }
+        } catch { }
+    }
+}
+
+# Method 3: Use handle64/handle.exe (Sysinternals) if available
+$handleTool = $null
+foreach ($path in @("handle64.exe", "handle.exe", "$env:SystemRoot\System32\handle64.exe")) {
+    if (Get-Command $path -ErrorAction SilentlyContinue) {
+        $handleTool = $path
+        break
+    }
+}
+
+if ($handleTool) {
+    Write-Host "  [i] Scanning open file handles (Sysinternals)..." -ForegroundColor DarkGray
+    $output = & $handleTool $INSTALL_DIR -accepteula 2>$null
+    $handlePids = $output | Select-String "pid: (\d+)" | ForEach-Object {
+        $_.Matches[0].Groups[1].Value
+    } | Sort-Object -Unique
+    foreach ($procPid in $handlePids) {
+        try {
+            Stop-Process -Id ([int]$procPid) -Force 2>$null
+            Write-Host "  [OK] Killed PID $procPid (via handle scan)" -ForegroundColor Green
+        } catch { }
+    }
+}
+
+if ($killed.Count -gt 0) {
+    Write-Host "  [i] Waiting for processes to exit..." -ForegroundColor DarkGray
+    Start-Sleep -Seconds 2
+} else {
+    Write-Host "  [OK] No running processes found" -ForegroundColor Green
+}
+
+Write-Host ""
+
+# --- Delete the install directory ---
+Write-Host "  [i] Removing $INSTALL_DIR ..." -ForegroundColor Cyan
+
+try {
+    Remove-Item -Recurse -Force $INSTALL_DIR -ErrorAction Stop
+    Write-Host "  [OK] Antigravity Deck has been removed." -ForegroundColor Green
+} catch {
+    Write-Host "  [!] Standard removal failed. Trying robocopy trick..." -ForegroundColor Yellow
+
+    $emptyDir = Join-Path $env:TEMP "ag_empty_$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $emptyDir | Out-Null
+    robocopy $emptyDir $INSTALL_DIR /MIR /NFL /NDL /NJH /NJS /NC /NS /NP 2>$null | Out-Null
+    Remove-Item -Recurse -Force $emptyDir 2>$null
+    Remove-Item -Recurse -Force $INSTALL_DIR 2>$null
+
+    if (Test-Path $INSTALL_DIR) {
+        Write-Host "  [!] Could not fully remove. Some files may still be locked." -ForegroundColor Red
+        Write-Host "      Try closing all terminals, IDE windows, and rerun this script." -ForegroundColor Yellow
+    } else {
+        Write-Host "  [OK] Antigravity Deck has been removed." -ForegroundColor Green
+    }
+}
+
+Write-Host ""

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# === Antigravity Deck — Uninstall (macOS / Linux) ===
+# Usage: curl -sL https://raw.githubusercontent.com/tysonnbt/Antigravity-Deck/main/scripts/uninstall.sh | bash
+
+INSTALL_DIR="$HOME/.antigravity-deck"
+
+echo ""
+echo "  🗑️  Antigravity Deck — Uninstall"
+echo "  ================================="
+echo ""
+echo "  Install location: $INSTALL_DIR"
+echo ""
+
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "  ℹ️  Nothing to uninstall — directory not found."
+    echo ""
+    exit 0
+fi
+
+# --- Kill processes with open handles inside the install dir ---
+echo "  🔍 Checking for running processes..."
+
+killed=0
+
+# Find processes whose command line references the install dir
+if command -v pgrep &>/dev/null; then
+    pids=$(pgrep -f "$INSTALL_DIR" 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        for pid in $pids; do
+            proc_name=$(ps -p "$pid" -o comm= 2>/dev/null || echo "unknown")
+            kill -9 "$pid" 2>/dev/null && {
+                echo "  ✅ Killed $proc_name (PID $pid)"
+                killed=$((killed + 1))
+            }
+        done
+    fi
+fi
+
+# macOS: use lsof to find any process with open files inside the dir
+if command -v lsof &>/dev/null; then
+    lsof_pids=$(lsof +D "$INSTALL_DIR" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u || true)
+    if [ -n "$lsof_pids" ]; then
+        for pid in $lsof_pids; do
+            proc_name=$(ps -p "$pid" -o comm= 2>/dev/null || echo "unknown")
+            kill -9 "$pid" 2>/dev/null && {
+                echo "  ✅ Killed $proc_name (PID $pid) [lsof]"
+                killed=$((killed + 1))
+            }
+        done
+    fi
+fi
+
+# Linux: use fuser to find processes with files open in the dir
+if command -v fuser &>/dev/null; then
+    fuser_pids=$(fuser -m "$INSTALL_DIR" 2>/dev/null || true)
+    if [ -n "$fuser_pids" ]; then
+        for pid in $fuser_pids; do
+            proc_name=$(ps -p "$pid" -o comm= 2>/dev/null || echo "unknown")
+            kill -9 "$pid" 2>/dev/null && {
+                echo "  ✅ Killed $proc_name (PID $pid) [fuser]"
+                killed=$((killed + 1))
+            }
+        done
+    fi
+fi
+
+if [ "$killed" -eq 0 ]; then
+    echo "  ✅ No running processes found"
+else
+    echo "  ⏳ Waiting for processes to exit..."
+    sleep 2
+fi
+
+echo ""
+
+# --- Delete the install directory ---
+echo "  🗑️  Removing $INSTALL_DIR ..."
+
+if rm -rf "$INSTALL_DIR" 2>/dev/null; then
+    echo "  ✅ Antigravity Deck has been removed."
+else
+    echo "  ⚠️  Standard removal failed — retrying with elevated permissions..."
+    sudo rm -rf "$INSTALL_DIR" 2>/dev/null && \
+        echo "  ✅ Antigravity Deck has been removed." || \
+        echo "  ❌ Could not remove directory. Please close all related processes and try again."
+fi
+
+echo ""


### PR DESCRIPTION
## Summary
Add one-command uninstall scripts for Windows and macOS/Linux.

## Changes
- **scripts/uninstall.ps1** — Kills node/cloudflared processes using the install dir (WMI scan + optional Sysinternals handle.exe), then removes `%LOCALAPPDATA%\AntigravityDeck` with robocopy fallback
- **scripts/uninstall.sh** — Kills processes via `pgrep`, `lsof` (macOS), `fuser` (Linux), then removes `~/.antigravity-deck` with sudo fallback
- **README.md** — Update uninstall section to use the new one-command scripts

## Why
A bare `Remove-Item` / `rm -rf` fails when the app is still running. These scripts handle process cleanup automatically before deleting.