### PR TITLE
feat: auto-focus chat input when opening a conversation

### DIFF
--- a/frontend/components/chat-view.tsx
+++ b/frontend/components/chat-view.tsx
@@ -266,7 +266,8 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
         // Use a short delay to let the DOM render the new steps first
         const timer = setTimeout(() => {
             bottomRef.current?.scrollIntoView({ behavior: 'instant' });
-            inputRef.current?.focus();
+            // Only auto-focus on desktop — on Android, programmatic focus triggers the soft keyboard
+            window.matchMedia('(pointer: fine)').matches && inputRef.current?.focus();
         }, 50);
         return () => clearTimeout(timer);
     }, [currentConvId]);


### PR DESCRIPTION
## Summary

  - Automatically focuses the chat textarea when a conversation is opened or switched, so users can
  start typing immediately without clicking the input first.

##  Changes

  - Added inputRef.current?.focus() in the existing useEffect that triggers on currentConvId change
  in chat-view.tsx, right after the scroll-to-bottom call.
