### PR TITLE
feat: setup scripts install from latest release tag

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -3,7 +3,28 @@
 
 $ErrorActionPreference = "Stop"
 $REPO        = "https://github.com/tysonnbt/Antigravity-Deck.git"
+$REPO_API    = "https://api.github.com/repos/tysonnbt/Antigravity-Deck"
 $INSTALL_DIR = Join-Path $env:LOCALAPPDATA "AntigravityDeck"
+
+# --- Resolve latest release tag ---
+function Get-LatestTag {
+    # Try GitHub API (no auth needed for public repos)
+    try {
+        $release = Invoke-RestMethod -Uri "$REPO_API/releases/latest" -TimeoutSec 10 2>$null
+        if ($release.tag_name) { return $release.tag_name }
+    } catch { }
+    # Fallback: git ls-remote tags
+    try {
+        $tags = (git ls-remote --tags --sort=-v:refname $REPO 'v*' 2>$null)
+        if ($tags) {
+            $first = ($tags -split "`n")[0]
+            $tag = ($first -replace '.*refs/tags/', '' -replace '\^{}', '').Trim()
+            if ($tag) { return $tag }
+        }
+    } catch { }
+    # Ultimate fallback
+    return "main"
+}
 
 Write-Host ""
 Write-Host "  Antigravity Deck -- One-Command Setup" -ForegroundColor Cyan
@@ -94,32 +115,35 @@ Write-Host ""
 # === Detect scenario ===
 $scenario = "fresh"       # fresh | up-to-date | updated
 $updatedFiles = @()
+$targetTag = Get-LatestTag
 
 if (Test-Path "$INSTALL_DIR\.git") {
     Push-Location $INSTALL_DIR
 
-    # Save current commit hash before pull
+    # Save current commit hash before update
     $hashBefore = (git rev-parse HEAD 2>$null)
+    $currentTag = (git describe --tags --exact-match HEAD 2>$null)
 
     Write-Host "  [i] Found existing install -- checking for updates..." -ForegroundColor Cyan
     try {
-        git fetch origin main --quiet 2>$null
+        git fetch origin --tags --quiet 2>$null
 
-        $localHash  = (git rev-parse HEAD 2>$null)
-        $remoteHash = (git rev-parse "origin/main" 2>$null)
+        # Re-resolve after fetch in case new tags appeared
+        $targetTag = Get-LatestTag
 
-        if ($localHash -eq $remoteHash) {
+        if ($currentTag -eq $targetTag) {
             $scenario = "up-to-date"
-            $shortHash = $localHash.Substring(0, 7)
-            Write-Host "  [OK] Already up to date ($shortHash)" -ForegroundColor Green
+            Write-Host "  [OK] Already on latest release ($targetTag)" -ForegroundColor Green
         }
         else {
-            # Count commits behind
-            $behind = (git rev-list --count "HEAD..origin/main" 2>$null)
-            Write-Host "  [i] $behind new commit(s) available -- pulling..." -ForegroundColor Yellow
+            if ($currentTag) {
+                Write-Host "  [i] New release available: $currentTag -> $targetTag" -ForegroundColor Yellow
+            } else {
+                Write-Host "  [i] Switching to release $targetTag..." -ForegroundColor Yellow
+            }
 
             $ErrorActionPreference = "Continue"
-            git pull --ff-only 2>$null
+            git -c advice.detachedHead=false checkout $targetTag --quiet 2>$null
             $ErrorActionPreference = "Stop"
 
             $hashAfter = (git rev-parse HEAD 2>$null)
@@ -132,12 +156,7 @@ if (Test-Path "$INSTALL_DIR\.git") {
             }
             $scenario = "updated"
 
-            if ($hashAfter) {
-                $shortNewHash = $hashAfter.Substring(0, 7)
-                Write-Host "  [OK] Updated to $shortNewHash" -ForegroundColor Green
-            } else {
-                Write-Host "  [OK] Updated successfully" -ForegroundColor Green
-            }
+            Write-Host "  [OK] Updated to $targetTag" -ForegroundColor Green
         }
     }
     catch {
@@ -151,7 +170,10 @@ else {
     Write-Host "  [i] First time setup -- cloning repository..." -ForegroundColor Cyan
     New-Item -ItemType Directory -Force -Path $INSTALL_DIR | Out-Null
     git clone $REPO $INSTALL_DIR
-    Write-Host "  [OK] Cloned successfully" -ForegroundColor Green
+    Push-Location $INSTALL_DIR
+    git -c advice.detachedHead=false checkout $targetTag --quiet 2>$null
+    Pop-Location
+    Write-Host "  [OK] Installed $targetTag" -ForegroundColor Green
 }
 
 Push-Location $INSTALL_DIR

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,24 @@
 set -e
 
 REPO="https://github.com/tysonnbt/Antigravity-Deck.git"
+REPO_API="https://api.github.com/repos/tysonnbt/Antigravity-Deck"
 INSTALL_DIR="$HOME/.antigravity-deck"
+
+# --- Resolve latest release tag ---
+get_latest_tag() {
+    # Try GitHub API (no auth needed for public repos)
+    local tag
+    tag=$(curl -sL "$REPO_API/releases/latest" 2>/dev/null \
+        | grep '"tag_name"' | head -1 \
+        | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    if [ -n "$tag" ] && [ "$tag" != "" ]; then echo "$tag"; return; fi
+    # Fallback: git ls-remote tags (sorted by version descending)
+    tag=$(git ls-remote --tags --sort=-v:refname "$REPO" 'v*' 2>/dev/null \
+        | head -1 | sed 's/.*refs\/tags\///' | sed 's/\^{}//')
+    if [ -n "$tag" ]; then echo "$tag"; return; fi
+    # Ultimate fallback: main branch
+    echo "main"
+}
 
 echo ""
 echo "  🔮 Antigravity Deck — One-Command Setup"
@@ -77,27 +94,32 @@ echo ""
 scenario="fresh"       # fresh | up-to-date | updated
 updated_files=""
 
+TARGET_TAG=$(get_latest_tag)
+
 if [ -d "$INSTALL_DIR/.git" ]; then
     cd "$INSTALL_DIR"
 
-    # Save current commit hash before pull
+    # Save current commit hash before update
     hash_before=$(git rev-parse HEAD 2>/dev/null || echo "")
+    current_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
 
     echo "  📂 Found existing install — checking for updates..."
 
-    if git fetch origin main --quiet 2>/dev/null; then
-        local_hash=$(git rev-parse HEAD 2>/dev/null)
-        remote_hash=$(git rev-parse "origin/main" 2>/dev/null)
+    if git fetch origin --tags --quiet 2>/dev/null; then
+        # Re-resolve after fetch in case new tags appeared
+        TARGET_TAG=$(get_latest_tag)
 
-        if [ "$local_hash" = "$remote_hash" ]; then
+        if [ "$current_tag" = "$TARGET_TAG" ]; then
             scenario="up-to-date"
-            echo "  ✅ Already up to date (${local_hash:0:7})"
+            echo "  ✅ Already on latest release ($TARGET_TAG)"
         else
-            # Count commits behind
-            behind=$(git rev-list --count "HEAD..origin/main" 2>/dev/null || echo "?")
-            echo "  📥 $behind new commit(s) available — pulling..."
+            if [ -n "$current_tag" ]; then
+                echo "  📥 New release available: $current_tag → $TARGET_TAG"
+            else
+                echo "  📥 Switching to release $TARGET_TAG..."
+            fi
 
-            git pull --ff-only 2>/dev/null
+            git -c advice.detachedHead=false checkout "$TARGET_TAG" --quiet 2>/dev/null
 
             hash_after=$(git rev-parse HEAD 2>/dev/null)
 
@@ -105,7 +127,7 @@ if [ -d "$INSTALL_DIR/.git" ]; then
             updated_files=$(git diff --name-only "$hash_before" "$hash_after" 2>/dev/null || echo "")
             scenario="updated"
 
-            echo "  ✅ Updated to ${hash_after:0:7}"
+            echo "  ✅ Updated to $TARGET_TAG"
         fi
     else
         echo "  ⚠️  Could not fetch updates (offline?) — continuing with current version"
@@ -116,7 +138,8 @@ else
     mkdir -p "$INSTALL_DIR"
     git clone "$REPO" "$INSTALL_DIR"
     cd "$INSTALL_DIR"
-    echo "  ✅ Cloned successfully"
+    git -c advice.detachedHead=false checkout "$TARGET_TAG" --quiet 2>/dev/null
+    echo "  ✅ Installed $TARGET_TAG"
 fi
 
 # === Smart dependency install ===


### PR DESCRIPTION
## Summary
- Setup scripts (`setup.sh` + `setup.ps1`) now resolve the latest GitHub release tag via API and checkout that specific version instead of always pulling from `main`
- Fallback chain: GitHub API → `git ls-remote --tags` → `main` branch
- Existing installs compare current tag vs latest and only update when a new release is available

## Test plan
- [ ] Run `setup.sh` on a fresh machine — should clone and checkout latest release tag
- [ ] Run `setup.ps1` on Windows — same behavior
- [ ] Run setup again without a new release — should show "Already on latest release"
- [ ] Create a new release and re-run — should detect and switch to new tag
- [ ] Test offline scenario — should gracefully continue with current version

## Documentation
- **README.md**: Updated One-Command Setup description to mention release-based installation and auto-update behavior. Added Push Notifications section (4 bullets). Added smart binary detection to Headless LS section. Added `lsBinaryPath` to Settings list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
