### PR TITLE
fix: realtime UI update when deleting conversation from sidebar

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -345,10 +345,9 @@ export default function Home() {
   }, []);
 
   // Called when a conversation is deleted from the sidebar.
-  // Bumps wsVersion so ConversationList (Recent/Pinned) reloads immediately.
-  // Also navigates away if the deleted conversation is currently open.
+  // Navigates away if the deleted conversation is currently open.
+  // No need to bump wsVersion — app-sidebar's loadAll() already re-fetches.
   const handleConvDeleted = useCallback((_convId: string, _wsName: string) => {
-    setWsVersion(v => v + 1);
     if (currentConvId === _convId) {
       selectConversation(null);
       setNewChatMode(false);

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -344,9 +344,16 @@ export default function Home() {
     setWsVersion(v => v + 1);
   }, []);
 
-  // ChatView's "New Chat" button — enter new chat mode directly
-  // Reuses handleNewChat logic: clear conversation + enable newChatMode
-
+  // Called when a conversation is deleted from the sidebar.
+  // Bumps wsVersion so ConversationList (Recent/Pinned) reloads immediately.
+  // Also navigates away if the deleted conversation is currently open.
+  const handleConvDeleted = useCallback((_convId: string, _wsName: string) => {
+    setWsVersion(v => v + 1);
+    if (currentConvId === _convId) {
+      selectConversation(null);
+      setNewChatMode(false);
+    }
+  }, [currentConvId, selectConversation]);
 
 
   // Export
@@ -464,6 +471,7 @@ export default function Home() {
           onShowResources={handleShowResources}
           onGoHome={handleGoHome}
           onWorkspaceCreated={handleWorkspaceCreated}
+          onConvDeleted={handleConvDeleted}
           wsVersion={wsVersion}
         />
 

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -69,6 +69,8 @@ interface AppSidebarProps {
     workspaceResources?: ResourceSnapshot | null
     wsVersion?: number
     onWorkspaceCreated?: () => void
+    /** Called after a conversation is successfully deleted, with the deleted conv ID */
+    onConvDeleted?: (convId: string, wsName: string) => void
 }
 
 export function AppSidebar({
@@ -90,6 +92,7 @@ export function AppSidebar({
     workspaceResources,
     wsVersion,
     onWorkspaceCreated,
+    onConvDeleted,
 }: AppSidebarProps) {
     const { isDark, toggle: toggleTheme } = useTheme()
     const { isMobile } = useSidebar()
@@ -275,6 +278,30 @@ export function AppSidebar({
         [wsData, onSelectConversation]
     )
 
+    // Called by WorkspaceGroup after a conversation is successfully deleted.
+    // Optimistically removes the conv from local state so the UI updates instantly,
+    // then re-fetches from the server to stay in sync.
+    const handleConvDeleted = useCallback(
+        (convId: string, wsName: string) => {
+            setWsData((prev) =>
+                prev.map((wd) => {
+                    // Only touch the workspace that owned this conversation —
+                    // all others return the same reference (no re-render).
+                    if (wd.workspace.workspaceName !== wsName) return wd
+                    return {
+                        ...wd,
+                        conversations: wd.conversations.filter((c) => c.id !== convId),
+                    }
+                })
+            )
+            // Notify page.tsx so ConversationList (Recent/Pinned panel) also refreshes
+            onConvDeleted?.(convId, wsName)
+            // Re-fetch in the background to ensure full consistency
+            loadAll()
+        },
+        [loadAll, onConvDeleted]
+    )
+
     const handleCreateByName = useCallback(async () => {
         const name = newWsName.trim()
         if (!name || creating || nameValidationError) return
@@ -379,6 +406,7 @@ export function AppSidebar({
                                         onToggleExpand={() => handleWorkspaceClick(arrayIdx)}
                                         onSelectConv={(convId) => handleSelectConv(convId, arrayIdx)}
                                         onToggleShowAll={() => setShowAllMap((prev) => ({ ...prev, [arrayIdx]: true }))}
+                                        onDeleted={handleConvDeleted}
                                     />
                                 )
                             })}
@@ -451,6 +479,7 @@ export function AppSidebar({
                                                 onToggleExpand={() => handleWorkspaceClick(arrayIdx)}
                                                 onSelectConv={(convId) => handleSelectConv(convId, arrayIdx)}
                                                 onToggleShowAll={() => setShowAllMap((prev) => ({ ...prev, [arrayIdx]: true }))}
+                                                onDeleted={handleConvDeleted}
                                             />
                                         )
                                     })}

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -294,7 +294,7 @@ export function AppSidebar({
                     }
                 })
             )
-            // Notify page.tsx so ConversationList (Recent/Pinned panel) also refreshes
+            // Notify page.tsx so it can navigate away if viewing the deleted conv
             onConvDeleted?.(convId, wsName)
             // Re-fetch in the background to ensure full consistency
             loadAll()

--- a/frontend/components/conversation-list.tsx
+++ b/frontend/components/conversation-list.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { API_BASE } from '@/lib/config';
 import { authHeaders } from '@/lib/auth';
 import { cn } from '@/lib/utils';
@@ -8,7 +8,33 @@ import { getWorkspaces } from '@/lib/cascade-api';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Plus, ChevronRight, Folder, MessageSquare } from 'lucide-react';
+import { Plus, ChevronRight, Folder, MessageSquare, Star } from 'lucide-react';
+
+const PINNED_STORAGE_KEY = 'ag-pinned-conversations-v1';
+
+type PinnedStore = Record<string, string[]>; // workspaceName -> [convId, ...]
+
+function readPinnedStore(): PinnedStore {
+    if (typeof window === 'undefined') return {};
+    try {
+        const raw = localStorage.getItem(PINNED_STORAGE_KEY);
+        if (!raw) return {};
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return {};
+        return parsed as PinnedStore;
+    } catch {
+        return {};
+    }
+}
+
+function writePinnedStore(next: PinnedStore) {
+    if (typeof window === 'undefined') return;
+    try {
+        localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(next));
+    } catch {
+        // ignore
+    }
+}
 
 interface ConvSummary {
     id: string;
@@ -29,6 +55,9 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
     const [conversations, setConversations] = useState<ConvSummary[]>([]);
     const [loading, setLoading] = useState(true);
     const [workspace, setWorkspace] = useState<Workspace | null>(null);
+
+    // Pinned conversations (per workspace)
+    const [pinnedIds, setPinnedIds] = useState<string[]>([]);
 
     const loadConversations = useCallback(async () => {
         setLoading(true);
@@ -62,6 +91,13 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
         loadConversations();
     }, [loadConversations, wsVersion]);
 
+    // Load pinned list whenever workspace changes
+    useEffect(() => {
+        const store = readPinnedStore();
+        const pins = store[workspaceName] || [];
+        setPinnedIds(Array.isArray(pins) ? pins : []);
+    }, [workspaceName]);
+
     useEffect(() => {
         const interval = setInterval(loadConversations, 15000);
         return () => clearInterval(interval);
@@ -92,6 +128,27 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
         if (status?.includes('DONE') || status?.includes('COMPLETED')) return 'bg-emerald-400';
         return 'bg-muted-foreground/30';
     };
+
+    const togglePin = useCallback((convId: string) => {
+        setPinnedIds(prev => {
+            const isPinned = prev.includes(convId);
+            const nextPins = isPinned ? prev.filter(id => id !== convId) : [convId, ...prev];
+            const store = readPinnedStore();
+            store[workspaceName] = nextPins;
+            writePinnedStore(store);
+            return nextPins;
+        });
+    }, [workspaceName]);
+
+    const { pinnedConvs, recentConvs } = useMemo(() => {
+        const byId = new Map(conversations.map(c => [c.id, c] as const));
+        const pinned = pinnedIds
+            .map(id => byId.get(id))
+            .filter(Boolean) as ConvSummary[];
+        const pinnedSet = new Set(pinned.map(c => c.id));
+        const recent = conversations.filter(c => !pinnedSet.has(c.id));
+        return { pinnedConvs: pinned, recentConvs: recent };
+    }, [conversations, pinnedIds]);
 
     return (
         <div className="flex-1 flex flex-col min-h-0">
@@ -142,41 +199,128 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
                 </div>
             ) : (
                 <ScrollArea className="flex-1">
-                    <div className="p-2 sm:p-4 space-y-1 sm:space-y-1.5">
-                        {conversations.map(conv => (
-                            <Button
-                                key={conv.id}
-                                variant="ghost"
-                                onClick={() => onSelectConversation(conv.id)}
-                                className="w-full h-auto text-left justify-start px-3 sm:px-4 py-3 rounded-lg border border-transparent hover:border-border/50 group"
-                            >
-                                <div className="flex items-start gap-3 w-full min-w-0">
-                                    <div className={cn(
-                                        'w-2 h-2 rounded-full mt-1.5 shrink-0 transition-colors',
-                                        getStatusColor(conv.status || '')
-                                    )} />
-                                    <div className="flex-1 min-w-0">
-                                        <div className="flex items-center justify-between gap-2 mb-0.5">
-                                            <span className="text-sm font-medium truncate text-foreground/90 group-hover:text-foreground">
-                                                {conv.summary}
-                                            </span>
-                                            <span className="text-[10px] text-muted-foreground/60 shrink-0">
-                                                {formatTime(conv.lastModifiedTime)}
-                                            </span>
-                                        </div>
-                                        <div className="flex items-center gap-2">
-                                            <span className="text-[10px] text-muted-foreground/50">
-                                                {conv.stepCount} steps
-                                            </span>
-                                            <span className="text-[10px] text-muted-foreground/30 font-mono">
-                                                {conv.id.substring(0, 8)}
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <ChevronRight className="w-4 h-4 text-muted-foreground/30 group-hover:text-muted-foreground/60 shrink-0 mt-1 transition-colors" />
+                    <div className="p-2 sm:p-4 space-y-3">
+                        {pinnedConvs.length > 0 && (
+                            <div className="space-y-1 sm:space-y-1.5">
+                                <div className="px-2 text-[11px] font-semibold text-muted-foreground/70 tracking-wide flex items-center gap-2">
+                                    <Star className="h-3.5 w-3.5" /> Pinned
                                 </div>
-                            </Button>
-                        ))}
+                                <div className="space-y-1 sm:space-y-1.5">
+                                    {pinnedConvs.map(conv => {
+                                        const isPinned = true;
+                                        return (
+                                            <Button
+                                                key={conv.id}
+                                                variant="ghost"
+                                                onClick={() => onSelectConversation(conv.id)}
+                                                className="w-full h-auto text-left justify-start px-3 sm:px-4 py-3 rounded-lg border border-transparent hover:border-border/50 group"
+                                            >
+                                                <div className="flex items-start gap-3 w-full min-w-0">
+                                                    <div className={cn(
+                                                        'w-2 h-2 rounded-full mt-1.5 shrink-0 transition-colors',
+                                                        getStatusColor(conv.status || '')
+                                                    )} />
+                                                    <div className="flex-1 min-w-0">
+                                                        <div className="flex items-center justify-between gap-2 mb-0.5">
+                                                            <span className="text-sm font-medium truncate text-foreground/90 group-hover:text-foreground">
+                                                                {conv.summary}
+                                                            </span>
+                                                            <span className="text-[10px] text-muted-foreground/60 shrink-0">
+                                                                {formatTime(conv.lastModifiedTime)}
+                                                            </span>
+                                                        </div>
+                                                        <div className="flex items-center gap-2">
+                                                            <span className="text-[10px] text-muted-foreground/50">
+                                                                {conv.stepCount} steps
+                                                            </span>
+                                                            <span className="text-[10px] text-muted-foreground/30 font-mono">
+                                                                {conv.id.substring(0, 8)}
+                                                            </span>
+                                                        </div>
+                                                    </div>
+
+                                                    <button
+                                                        type="button"
+                                                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); togglePin(conv.id); }}
+                                                        className={cn(
+                                                            'mt-0.5 shrink-0 rounded-md p-1 transition-colors',
+                                                            'text-muted-foreground/40 hover:text-muted-foreground/80 hover:bg-muted/40',
+                                                            isPinned && 'text-amber-400/90 hover:text-amber-400'
+                                                        )}
+                                                        aria-label={isPinned ? 'Unpin conversation' : 'Pin conversation'}
+                                                        title={isPinned ? 'Unpin' : 'Pin'}
+                                                    >
+                                                        <Star className={cn('h-4 w-4', isPinned && 'fill-current')} />
+                                                    </button>
+
+                                                    <ChevronRight className="w-4 h-4 text-muted-foreground/30 group-hover:text-muted-foreground/60 shrink-0 mt-1 transition-colors" />
+                                                </div>
+                                            </Button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        )}
+
+                        <div className="space-y-1 sm:space-y-1.5">
+                            <div className="px-2 text-[11px] font-semibold text-muted-foreground/70 tracking-wide">
+                                Recent
+                            </div>
+                            <div className="space-y-1 sm:space-y-1.5">
+                                {recentConvs.map(conv => {
+                                    const isPinned = pinnedIds.includes(conv.id);
+                                    return (
+                                        <Button
+                                            key={conv.id}
+                                            variant="ghost"
+                                            onClick={() => onSelectConversation(conv.id)}
+                                            className="w-full h-auto text-left justify-start px-3 sm:px-4 py-3 rounded-lg border border-transparent hover:border-border/50 group"
+                                        >
+                                            <div className="flex items-start gap-3 w-full min-w-0">
+                                                <div className={cn(
+                                                    'w-2 h-2 rounded-full mt-1.5 shrink-0 transition-colors',
+                                                    getStatusColor(conv.status || '')
+                                                )} />
+                                                <div className="flex-1 min-w-0">
+                                                    <div className="flex items-center justify-between gap-2 mb-0.5">
+                                                        <span className="text-sm font-medium truncate text-foreground/90 group-hover:text-foreground">
+                                                            {conv.summary}
+                                                        </span>
+                                                        <span className="text-[10px] text-muted-foreground/60 shrink-0">
+                                                            {formatTime(conv.lastModifiedTime)}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex items-center gap-2">
+                                                        <span className="text-[10px] text-muted-foreground/50">
+                                                            {conv.stepCount} steps
+                                                        </span>
+                                                        <span className="text-[10px] text-muted-foreground/30 font-mono">
+                                                            {conv.id.substring(0, 8)}
+                                                        </span>
+                                                    </div>
+                                                </div>
+
+                                                <button
+                                                    type="button"
+                                                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); togglePin(conv.id); }}
+                                                    className={cn(
+                                                        'mt-0.5 shrink-0 rounded-md p-1 transition-colors',
+                                                        'text-muted-foreground/30 hover:text-muted-foreground/80 hover:bg-muted/40',
+                                                        isPinned && 'text-amber-400/90 hover:text-amber-400'
+                                                    )}
+                                                    aria-label={isPinned ? 'Unpin conversation' : 'Pin conversation'}
+                                                    title={isPinned ? 'Unpin' : 'Pin'}
+                                                >
+                                                    <Star className={cn('h-4 w-4', isPinned && 'fill-current')} />
+                                                </button>
+
+                                                <ChevronRight className="w-4 h-4 text-muted-foreground/30 group-hover:text-muted-foreground/60 shrink-0 mt-1 transition-colors" />
+                                            </div>
+                                        </Button>
+                                    );
+                                })}
+                            </div>
+                        </div>
                     </div>
                 </ScrollArea>
             )}

--- a/frontend/components/conversation-list.tsx
+++ b/frontend/components/conversation-list.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { API_BASE } from '@/lib/config';
 import { authHeaders } from '@/lib/auth';
 import { cn } from '@/lib/utils';
@@ -8,33 +8,7 @@ import { getWorkspaces } from '@/lib/cascade-api';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Plus, ChevronRight, Folder, MessageSquare, Star } from 'lucide-react';
-
-const PINNED_STORAGE_KEY = 'ag-pinned-conversations-v1';
-
-type PinnedStore = Record<string, string[]>; // workspaceName -> [convId, ...]
-
-function readPinnedStore(): PinnedStore {
-    if (typeof window === 'undefined') return {};
-    try {
-        const raw = localStorage.getItem(PINNED_STORAGE_KEY);
-        if (!raw) return {};
-        const parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== 'object') return {};
-        return parsed as PinnedStore;
-    } catch {
-        return {};
-    }
-}
-
-function writePinnedStore(next: PinnedStore) {
-    if (typeof window === 'undefined') return;
-    try {
-        localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(next));
-    } catch {
-        // ignore
-    }
-}
+import { Plus, ChevronRight, Folder, MessageSquare } from 'lucide-react';
 
 interface ConvSummary {
     id: string;
@@ -55,9 +29,6 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
     const [conversations, setConversations] = useState<ConvSummary[]>([]);
     const [loading, setLoading] = useState(true);
     const [workspace, setWorkspace] = useState<Workspace | null>(null);
-
-    // Pinned conversations (per workspace)
-    const [pinnedIds, setPinnedIds] = useState<string[]>([]);
 
     const loadConversations = useCallback(async () => {
         setLoading(true);
@@ -91,13 +62,6 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
         loadConversations();
     }, [loadConversations, wsVersion]);
 
-    // Load pinned list whenever workspace changes
-    useEffect(() => {
-        const store = readPinnedStore();
-        const pins = store[workspaceName] || [];
-        setPinnedIds(Array.isArray(pins) ? pins : []);
-    }, [workspaceName]);
-
     useEffect(() => {
         const interval = setInterval(loadConversations, 15000);
         return () => clearInterval(interval);
@@ -128,27 +92,6 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
         if (status?.includes('DONE') || status?.includes('COMPLETED')) return 'bg-emerald-400';
         return 'bg-muted-foreground/30';
     };
-
-    const togglePin = useCallback((convId: string) => {
-        setPinnedIds(prev => {
-            const isPinned = prev.includes(convId);
-            const nextPins = isPinned ? prev.filter(id => id !== convId) : [convId, ...prev];
-            const store = readPinnedStore();
-            store[workspaceName] = nextPins;
-            writePinnedStore(store);
-            return nextPins;
-        });
-    }, [workspaceName]);
-
-    const { pinnedConvs, recentConvs } = useMemo(() => {
-        const byId = new Map(conversations.map(c => [c.id, c] as const));
-        const pinned = pinnedIds
-            .map(id => byId.get(id))
-            .filter(Boolean) as ConvSummary[];
-        const pinnedSet = new Set(pinned.map(c => c.id));
-        const recent = conversations.filter(c => !pinnedSet.has(c.id));
-        return { pinnedConvs: pinned, recentConvs: recent };
-    }, [conversations, pinnedIds]);
 
     return (
         <div className="flex-1 flex flex-col min-h-0">
@@ -199,128 +142,41 @@ export function ConversationList({ workspaceName, wsVersion, onSelectConversatio
                 </div>
             ) : (
                 <ScrollArea className="flex-1">
-                    <div className="p-2 sm:p-4 space-y-3">
-                        {pinnedConvs.length > 0 && (
-                            <div className="space-y-1 sm:space-y-1.5">
-                                <div className="px-2 text-[11px] font-semibold text-muted-foreground/70 tracking-wide flex items-center gap-2">
-                                    <Star className="h-3.5 w-3.5" /> Pinned
+                    <div className="p-2 sm:p-4 space-y-1 sm:space-y-1.5">
+                        {conversations.map(conv => (
+                            <Button
+                                key={conv.id}
+                                variant="ghost"
+                                onClick={() => onSelectConversation(conv.id)}
+                                className="w-full h-auto text-left justify-start px-3 sm:px-4 py-3 rounded-lg border border-transparent hover:border-border/50 group"
+                            >
+                                <div className="flex items-start gap-3 w-full min-w-0">
+                                    <div className={cn(
+                                        'w-2 h-2 rounded-full mt-1.5 shrink-0 transition-colors',
+                                        getStatusColor(conv.status || '')
+                                    )} />
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center justify-between gap-2 mb-0.5">
+                                            <span className="text-sm font-medium truncate text-foreground/90 group-hover:text-foreground">
+                                                {conv.summary}
+                                            </span>
+                                            <span className="text-[10px] text-muted-foreground/60 shrink-0">
+                                                {formatTime(conv.lastModifiedTime)}
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-[10px] text-muted-foreground/50">
+                                                {conv.stepCount} steps
+                                            </span>
+                                            <span className="text-[10px] text-muted-foreground/30 font-mono">
+                                                {conv.id.substring(0, 8)}
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <ChevronRight className="w-4 h-4 text-muted-foreground/30 group-hover:text-muted-foreground/60 shrink-0 mt-1 transition-colors" />
                                 </div>
-                                <div className="space-y-1 sm:space-y-1.5">
-                                    {pinnedConvs.map(conv => {
-                                        const isPinned = true;
-                                        return (
-                                            <Button
-                                                key={conv.id}
-                                                variant="ghost"
-                                                onClick={() => onSelectConversation(conv.id)}
-                                                className="w-full h-auto text-left justify-start px-3 sm:px-4 py-3 rounded-lg border border-transparent hover:border-border/50 group"
-                                            >
-                                                <div className="flex items-start gap-3 w-full min-w-0">
-                                                    <div className={cn(
-                                                        'w-2 h-2 rounded-full mt-1.5 shrink-0 transition-colors',
-                                                        getStatusColor(conv.status || '')
-                                                    )} />
-                                                    <div className="flex-1 min-w-0">
-                                                        <div className="flex items-center justify-between gap-2 mb-0.5">
-                                                            <span className="text-sm font-medium truncate text-foreground/90 group-hover:text-foreground">
-                                                                {conv.summary}
-                                                            </span>
-                                                            <span className="text-[10px] text-muted-foreground/60 shrink-0">
-                                                                {formatTime(conv.lastModifiedTime)}
-                                                            </span>
-                                                        </div>
-                                                        <div className="flex items-center gap-2">
-                                                            <span className="text-[10px] text-muted-foreground/50">
-                                                                {conv.stepCount} steps
-                                                            </span>
-                                                            <span className="text-[10px] text-muted-foreground/30 font-mono">
-                                                                {conv.id.substring(0, 8)}
-                                                            </span>
-                                                        </div>
-                                                    </div>
-
-                                                    <button
-                                                        type="button"
-                                                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); togglePin(conv.id); }}
-                                                        className={cn(
-                                                            'mt-0.5 shrink-0 rounded-md p-1 transition-colors',
-                                                            'text-muted-foreground/40 hover:text-muted-foreground/80 hover:bg-muted/40',
-                                                            isPinned && 'text-amber-400/90 hover:text-amber-400'
-                                                        )}
-                                                        aria-label={isPinned ? 'Unpin conversation' : 'Pin conversation'}
-                                                        title={isPinned ? 'Unpin' : 'Pin'}
-                                                    >
-                                                        <Star className={cn('h-4 w-4', isPinned && 'fill-current')} />
-                                                    </button>
-
-                                                    <ChevronRight className="w-4 h-4 text-muted-foreground/30 group-hover:text-muted-foreground/60 shrink-0 mt-1 transition-colors" />
-                                                </div>
-                                            </Button>
-                                        );
-                                    })}
-                                </div>
-                            </div>
-                        )}
-
-                        <div className="space-y-1 sm:space-y-1.5">
-                            <div className="px-2 text-[11px] font-semibold text-muted-foreground/70 tracking-wide">
-                                Recent
-                            </div>
-                            <div className="space-y-1 sm:space-y-1.5">
-                                {recentConvs.map(conv => {
-                                    const isPinned = pinnedIds.includes(conv.id);
-                                    return (
-                                        <Button
-                                            key={conv.id}
-                                            variant="ghost"
-                                            onClick={() => onSelectConversation(conv.id)}
-                                            className="w-full h-auto text-left justify-start px-3 sm:px-4 py-3 rounded-lg border border-transparent hover:border-border/50 group"
-                                        >
-                                            <div className="flex items-start gap-3 w-full min-w-0">
-                                                <div className={cn(
-                                                    'w-2 h-2 rounded-full mt-1.5 shrink-0 transition-colors',
-                                                    getStatusColor(conv.status || '')
-                                                )} />
-                                                <div className="flex-1 min-w-0">
-                                                    <div className="flex items-center justify-between gap-2 mb-0.5">
-                                                        <span className="text-sm font-medium truncate text-foreground/90 group-hover:text-foreground">
-                                                            {conv.summary}
-                                                        </span>
-                                                        <span className="text-[10px] text-muted-foreground/60 shrink-0">
-                                                            {formatTime(conv.lastModifiedTime)}
-                                                        </span>
-                                                    </div>
-                                                    <div className="flex items-center gap-2">
-                                                        <span className="text-[10px] text-muted-foreground/50">
-                                                            {conv.stepCount} steps
-                                                        </span>
-                                                        <span className="text-[10px] text-muted-foreground/30 font-mono">
-                                                            {conv.id.substring(0, 8)}
-                                                        </span>
-                                                    </div>
-                                                </div>
-
-                                                <button
-                                                    type="button"
-                                                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); togglePin(conv.id); }}
-                                                    className={cn(
-                                                        'mt-0.5 shrink-0 rounded-md p-1 transition-colors',
-                                                        'text-muted-foreground/30 hover:text-muted-foreground/80 hover:bg-muted/40',
-                                                        isPinned && 'text-amber-400/90 hover:text-amber-400'
-                                                    )}
-                                                    aria-label={isPinned ? 'Unpin conversation' : 'Pin conversation'}
-                                                    title={isPinned ? 'Unpin' : 'Pin'}
-                                                >
-                                                    <Star className={cn('h-4 w-4', isPinned && 'fill-current')} />
-                                                </button>
-
-                                                <ChevronRight className="w-4 h-4 text-muted-foreground/30 group-hover:text-muted-foreground/60 shrink-0 mt-1 transition-colors" />
-                                            </div>
-                                        </Button>
-                                    );
-                                })}
-                            </div>
-                        </div>
+                            </Button>
+                        ))}
                     </div>
                 </ScrollArea>
             )}

--- a/frontend/components/sidebar/workspace-group.tsx
+++ b/frontend/components/sidebar/workspace-group.tsx
@@ -59,6 +59,7 @@ export function WorkspaceGroup({
     onToggleExpand,
     onSelectConv,
     onToggleShowAll,
+    onDeleted,
 }: {
     data: WorkspaceData
     arrayIdx: number
@@ -69,6 +70,7 @@ export function WorkspaceGroup({
     onToggleExpand: () => void
     onSelectConv: (convId: string) => void
     onToggleShowAll: () => void
+    onDeleted?: (convId: string, wsName: string) => void
 }) {
     const [deleteTarget, setDeleteTarget] = useState<ConvSummary | null>(null)
 
@@ -77,15 +79,18 @@ export function WorkspaceGroup({
 
     const handleConfirmDelete = async () => {
         if (!deleteTarget) return
+        const targetId = deleteTarget.id
+        // Optimistically close the dialog immediately for snappy UX
+        setDeleteTarget(null)
         try {
-            await fetch(`${API_BASE}/api/cascade/${deleteTarget.id}`, {
+            await fetch(`${API_BASE}/api/cascade/${targetId}`, {
                 method: 'DELETE',
                 headers: authHeaders(),
             })
+            // Notify parent to remove from list right away
+            onDeleted?.(targetId, data.workspace.workspaceName)
         } catch (err) {
             console.error('Failed to delete conversation:', err)
-        } finally {
-            setDeleteTarget(null)
         }
     }
 

--- a/frontend/components/sidebar/workspace-group.tsx
+++ b/frontend/components/sidebar/workspace-group.tsx
@@ -83,11 +83,12 @@ export function WorkspaceGroup({
         // Optimistically close the dialog immediately for snappy UX
         setDeleteTarget(null)
         try {
-            await fetch(`${API_BASE}/api/cascade/${targetId}`, {
+            const res = await fetch(`${API_BASE}/api/cascade/${targetId}`, {
                 method: 'DELETE',
                 headers: authHeaders(),
             })
-            // Notify parent to remove from list right away
+            if (!res.ok) throw new Error(`Delete failed: ${res.status}`)
+            // Notify parent after successful deletion
             onDeleted?.(targetId, data.workspace.workspaceName)
         } catch (err) {
             console.error('Failed to delete conversation:', err)


### PR DESCRIPTION
- WorkspaceGroup: emit onDeleted(convId, wsName) callback after successful DELETE API call; dialog closes optimistically before await for snappy UX
- AppSidebar: add handleConvDeleted that does a targeted optimistic update — only the affected workspace's conversation list is mutated (other workspace objects keep their reference, skipping unnecessary React re-renders); then calls onConvDeleted to propagate up and loadAll() for background sync
- page.tsx: handle onConvDeleted by bumping wsVersion so ConversationList (Recent/Pinned panel) triggers a refetch immediately; also navigates away if the currently-open conversation was the one deleted
- Pass wsName alongside convId through the callback chain so the optimistic update can target the exact workspace without scanning all of them