### PR TITLE
feat: rollback-to-checkpoint for conversations

### DIFF
--- a/frontend/components/chat-view.tsx
+++ b/frontend/components/chat-view.tsx
@@ -593,7 +593,8 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
                                     const animClass = isRecent ? 'message-animate' : '';
                                     if (group.type === 'user') {
                                         const { step, originalIndex } = group.steps[0];
-                                        return <div key={`u-${gIdx}`} className={animClass}><UserMessage step={step} index={originalIndex} stepIndex={baseIndex + originalIndex} onRollback={handleRollback} cascadeStatus={cascadeStatus} /></div>;
+                                        const isFirstUser = !groups.slice(0, gIdx).some(g => g.type === 'user');
+                                        return <div key={`u-${gIdx}`} className={animClass}><UserMessage step={step} index={originalIndex} stepIndex={baseIndex + originalIndex} onRollback={isFirstUser ? undefined : handleRollback} cascadeStatus={cascadeStatus} /></div>;
                                     }
                                     if (group.type === 'response') {
                                         const { step, originalIndex } = group.steps[0];

--- a/frontend/components/chat-view.tsx
+++ b/frontend/components/chat-view.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { Step } from '@/lib/types';
 import { extractStepContent, getStepConfig } from '@/lib/step-utils';
-import { cascadeSend, cascadeSubmit, cascadeCancel, cascadeInteract, getWorkspaces, getModels, getAutoAcceptState, setAutoAcceptState, saveMedia, clearConversationCache, fetchWorkflows } from '@/lib/cascade-api';
+import { cascadeSend, cascadeSubmit, cascadeCancel, cascadeInteract, cascadeRevert, getWorkspaces, getModels, getAutoAcceptState, setAutoAcceptState, saveMedia, clearConversationCache, fetchWorkflows } from '@/lib/cascade-api';
 import type { Workspace, CascadeModel, MediaItem, WorkflowItem } from '@/lib/cascade-api';
 import { API_BASE } from '@/lib/config';
 import { authHeaders } from '@/lib/auth';
@@ -423,6 +423,14 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
         catch (e) { console.error('Interact error:', e); }
     }, [activeCascadeId]);
 
+    // Rollback to a specific step
+    const handleRollback = useCallback(async (stepIndex: number) => {
+        if (!activeCascadeId) return;
+        setPendingMessage(null);
+        try { await cascadeRevert(activeCascadeId, stepIndex); }
+        catch (e) { console.error('Rollback error:', e); }
+    }, [activeCascadeId]);
+
     // New chat
     const handleNewChat = useCallback(() => {
         setLocalCascadeId(null);
@@ -585,7 +593,7 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
                                     const animClass = isRecent ? 'message-animate' : '';
                                     if (group.type === 'user') {
                                         const { step, originalIndex } = group.steps[0];
-                                        return <div key={`u-${gIdx}`} className={animClass}><UserMessage step={step} index={originalIndex} /></div>;
+                                        return <div key={`u-${gIdx}`} className={animClass}><UserMessage step={step} index={originalIndex} stepIndex={baseIndex + originalIndex} onRollback={handleRollback} cascadeStatus={cascadeStatus} /></div>;
                                     }
                                     if (group.type === 'response') {
                                         const { step, originalIndex } = group.steps[0];

--- a/frontend/components/chat-view.tsx
+++ b/frontend/components/chat-view.tsx
@@ -593,8 +593,7 @@ export function ChatView({ steps, baseIndex = 0, stepCount = 0, loadingOlder = f
                                     const animClass = isRecent ? 'message-animate' : '';
                                     if (group.type === 'user') {
                                         const { step, originalIndex } = group.steps[0];
-                                        const isFirstUser = !groups.slice(0, gIdx).some(g => g.type === 'user');
-                                        return <div key={`u-${gIdx}`} className={animClass}><UserMessage step={step} index={originalIndex} stepIndex={baseIndex + originalIndex} onRollback={isFirstUser ? undefined : handleRollback} cascadeStatus={cascadeStatus} /></div>;
+                                        return <div key={`u-${gIdx}`} className={animClass}><UserMessage step={step} index={originalIndex} stepIndex={baseIndex + originalIndex} onRollback={handleRollback} cascadeStatus={cascadeStatus} /></div>;
                                     }
                                     if (group.type === 'response') {
                                         const { step, originalIndex } = group.steps[0];

--- a/frontend/components/chat/user-message.tsx
+++ b/frontend/components/chat/user-message.tsx
@@ -31,14 +31,14 @@ export const UserMessage = memo(function UserMessage({ step, index, stepIndex, o
     }, [confirmRollback]);
 
     const isActive = cascadeStatus === 'CASCADE_RUN_STATUS_RUNNING' || cascadeStatus === 'CASCADE_RUN_STATUS_WAITING_FOR_USER';
-    const canRollback = onRollback && stepIndex != null && stepIndex > 0 && !isActive;
+    const canRollback = onRollback && stepIndex != null && !isActive;
 
     const handleRollbackClick = useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
         if (!canRollback) return;
         if (confirmRollback) {
             setConfirmRollback(false);
-            onRollback(stepIndex - 1);
+            onRollback(Math.max(0, stepIndex - 1));
         } else {
             setConfirmRollback(true);
         }

--- a/frontend/components/chat/user-message.tsx
+++ b/frontend/components/chat/user-message.tsx
@@ -69,9 +69,35 @@ export const UserMessage = memo(function UserMessage({ step, index, stepIndex, o
     return (
         <div className="flex justify-end mb-4">
             <div className="max-w-[80%] group relative rounded-lg rounded-br-md px-4 py-3 bg-blue-600/20 border border-blue-500/20 overflow-hidden min-w-0">
-                <div className="flex items-center gap-2 mb-1.5">
-                    <span className="text-[10px] font-bold text-blue-400 uppercase tracking-widest">You</span>
-                    <span className="text-[10px] text-muted-foreground/40 opacity-0 group-hover:opacity-100">#{index + 1}</span>
+                <div className="flex items-center justify-between gap-2 mb-1.5">
+                    <div className="flex items-center gap-2">
+                        <span className="text-[10px] font-bold text-blue-400 uppercase tracking-widest">You</span>
+                        <span className="text-[10px] text-muted-foreground/40 opacity-0 group-hover:opacity-100">#{index + 1}</span>
+                    </div>
+                    <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {canRollback && (
+                            <Button
+                                variant="ghost"
+                                size={confirmRollback ? 'sm' : 'icon'}
+                                className={confirmRollback
+                                    ? 'h-5 px-2 text-[10px] text-orange-400 hover:text-orange-300 hover:bg-orange-500/10'
+                                    : 'h-5 w-5 text-muted-foreground/50 hover:text-foreground'}
+                                onClick={handleRollbackClick}
+                                title="Rollback to this message"
+                            >
+                                {confirmRollback ? 'Confirm?' : <RotateCcw className="h-3 w-3" />}
+                            </Button>
+                        )}
+                        <RawJsonViewer step={step} />
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-5 w-5 text-muted-foreground/50 hover:text-foreground"
+                            onClick={(e) => copy(content, e)}
+                        >
+                            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                        </Button>
+                    </div>
                 </div>
 
                 {/* Images */}
@@ -90,30 +116,6 @@ export const UserMessage = memo(function UserMessage({ step, index, stepIndex, o
                 )}
 
                 {content && <div className="text-sm leading-relaxed"><MarkdownRenderer content={content} /></div>}
-                <div className="absolute bottom-1.5 right-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                    {canRollback && (
-                        <Button
-                            variant="ghost"
-                            size={confirmRollback ? 'sm' : 'icon'}
-                            className={confirmRollback
-                                ? 'h-5 px-2 text-[10px] text-orange-400 hover:text-orange-300 hover:bg-orange-500/10'
-                                : 'h-5 w-5 text-muted-foreground/50 hover:text-foreground'}
-                            onClick={handleRollbackClick}
-                            title="Rollback to this message"
-                        >
-                            {confirmRollback ? 'Confirm?' : <RotateCcw className="h-3 w-3" />}
-                        </Button>
-                    )}
-                    <RawJsonViewer step={step} />
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-5 w-5 text-muted-foreground/50 hover:text-foreground"
-                        onClick={(e) => copy(content, e)}
-                    >
-                        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-                    </Button>
-                </div>
             </div>
         </div>
     );

--- a/frontend/components/chat/user-message.tsx
+++ b/frontend/components/chat/user-message.tsx
@@ -31,14 +31,14 @@ export const UserMessage = memo(function UserMessage({ step, index, stepIndex, o
     }, [confirmRollback]);
 
     const isActive = cascadeStatus === 'CASCADE_RUN_STATUS_RUNNING' || cascadeStatus === 'CASCADE_RUN_STATUS_WAITING_FOR_USER';
-    const canRollback = onRollback && stepIndex != null && !isActive;
+    const canRollback = onRollback && stepIndex != null && stepIndex > 0 && !isActive;
 
     const handleRollbackClick = useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
         if (!canRollback) return;
         if (confirmRollback) {
             setConfirmRollback(false);
-            onRollback(stepIndex);
+            onRollback(stepIndex - 1);
         } else {
             setConfirmRollback(true);
         }

--- a/frontend/components/chat/user-message.tsx
+++ b/frontend/components/chat/user-message.tsx
@@ -90,7 +90,7 @@ export const UserMessage = memo(function UserMessage({ step, index, stepIndex, o
                 )}
 
                 {content && <div className="text-sm leading-relaxed"><MarkdownRenderer content={content} /></div>}
-                <div className="absolute top-2 right-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                <div className="absolute bottom-1.5 right-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
                     {canRollback && (
                         <Button
                             variant="ghost"

--- a/frontend/components/chat/user-message.tsx
+++ b/frontend/components/chat/user-message.tsx
@@ -38,7 +38,7 @@ export const UserMessage = memo(function UserMessage({ step, index, stepIndex, o
         if (!canRollback) return;
         if (confirmRollback) {
             setConfirmRollback(false);
-            onRollback(Math.max(0, stepIndex - 1));
+            onRollback(stepIndex - 1);
         } else {
             setConfirmRollback(true);
         }

--- a/frontend/components/chat/user-message.tsx
+++ b/frontend/components/chat/user-message.tsx
@@ -1,15 +1,48 @@
 'use client';
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import { Step } from '@/lib/types';
 import { extractStepContent } from '@/lib/step-utils';
 import { MarkdownRenderer } from '../markdown-renderer';
 import { useCopy } from './chat-helpers';
 import { RawJsonViewer } from './raw-json-viewer';
 import { Button } from '@/components/ui/button';
-import { Copy, Check } from 'lucide-react';
-export const UserMessage = memo(function UserMessage({ step, index }: { step: Step; index: number }) {
+import { Copy, Check, RotateCcw } from 'lucide-react';
+
+interface UserMessageProps {
+    step: Step;
+    index: number;
+    stepIndex?: number;
+    onRollback?: (stepIndex: number) => void;
+    cascadeStatus?: string;
+}
+
+export const UserMessage = memo(function UserMessage({ step, index, stepIndex, onRollback, cascadeStatus }: UserMessageProps) {
     const { copied, copy } = useCopy();
     const content = useMemo(() => extractStepContent(step) || '', [step]);
+    const [confirmRollback, setConfirmRollback] = useState(false);
+    const confirmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Auto-dismiss confirm state after 3s
+    useEffect(() => {
+        if (confirmRollback) {
+            confirmTimer.current = setTimeout(() => setConfirmRollback(false), 3000);
+            return () => { if (confirmTimer.current) clearTimeout(confirmTimer.current); };
+        }
+    }, [confirmRollback]);
+
+    const isActive = cascadeStatus === 'CASCADE_RUN_STATUS_RUNNING' || cascadeStatus === 'CASCADE_RUN_STATUS_WAITING_FOR_USER';
+    const canRollback = onRollback && stepIndex != null && !isActive;
+
+    const handleRollbackClick = useCallback((e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!canRollback) return;
+        if (confirmRollback) {
+            setConfirmRollback(false);
+            onRollback(stepIndex);
+        } else {
+            setConfirmRollback(true);
+        }
+    }, [canRollback, confirmRollback, onRollback, stepIndex]);
 
     // Extract images: from optimistic step (_media with dataUrl) or real step (userInput.media with thumbnail)
     const images = useMemo(() => {
@@ -58,6 +91,19 @@ export const UserMessage = memo(function UserMessage({ step, index }: { step: St
 
                 {content && <div className="text-sm leading-relaxed"><MarkdownRenderer content={content} /></div>}
                 <div className="absolute top-2 right-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                    {canRollback && (
+                        <Button
+                            variant="ghost"
+                            size={confirmRollback ? 'sm' : 'icon'}
+                            className={confirmRollback
+                                ? 'h-5 px-2 text-[10px] text-orange-400 hover:text-orange-300 hover:bg-orange-500/10'
+                                : 'h-5 w-5 text-muted-foreground/50 hover:text-foreground'}
+                            onClick={handleRollbackClick}
+                            title="Rollback to this message"
+                        >
+                            {confirmRollback ? 'Confirm?' : <RotateCcw className="h-3 w-3" />}
+                        </Button>
+                    )}
                     <RawJsonViewer step={step} />
                     <Button
                         variant="ghost"
@@ -73,4 +119,3 @@ export const UserMessage = memo(function UserMessage({ step, index }: { step: St
     );
 });
 UserMessage.displayName = 'UserMessage';
-

--- a/frontend/lib/cascade-api.ts
+++ b/frontend/lib/cascade-api.ts
@@ -219,6 +219,28 @@ export async function getModels(): Promise<{ models: CascadeModel[]; defaultMode
     return res.json();
 }
 
+// Preview what reverting to a step would do
+export async function cascadeRevertPreview(cascadeId: string, stepIndex: number): Promise<object> {
+    const res = await fetch(`${API_BASE}/api/cascade/${cascadeId}/revert-preview`, {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ stepIndex }),
+    });
+    if (!res.ok) throw new Error(`Revert preview failed: ${res.status}`);
+    return res.json();
+}
+
+// Revert cascade to a specific step (rollback)
+export async function cascadeRevert(cascadeId: string, stepIndex: number): Promise<object> {
+    const res = await fetch(`${API_BASE}/api/cascade/${cascadeId}/revert`, {
+        method: 'POST',
+        headers: authHeaders(),
+        body: JSON.stringify({ stepIndex }),
+    });
+    if (!res.ok) throw new Error(`Revert failed: ${res.status}`);
+    return res.json();
+}
+
 // Cancel an active cascade invocation
 export async function cascadeCancel(cascadeId: string): Promise<object> {
     const res = await fetch(`${API_BASE}/api/cascade/${cascadeId}/cancel`, { method: 'POST', headers: authHeaders() });

--- a/src/detector.js
+++ b/src/detector.js
@@ -151,41 +151,32 @@ async function detectPorts(pid) {
 async function findApiPort(ports, csrfToken) {
     if (!ports || !ports.length || !csrfToken) return null;
     const headers = { 'Content-Type': 'application/json', 'Connect-Protocol-Version': '1', 'X-Codeium-Csrf-Token': csrfToken };
+    const endpoint = '/exa.language_server_pb.LanguageServerService/GetUserStatus';
+
+    const probes = [
+        { label: 'HTTPS/IPv4',    url: (p) => `https://127.0.0.1:${p}${endpoint}`,  tls: true },
+        { label: 'HTTP/localhost', url: (p) => `http://localhost:${p}${endpoint}`,    tls: false },
+        { label: 'HTTPS/IPv6',    url: (p) => `https://[::1]:${p}${endpoint}`,       tls: true },
+        { label: 'HTTP/IPv6',     url: (p) => `http://[::1]:${p}${endpoint}`,        tls: false },
+    ];
+
     for (const port of ports) {
-        // 1. HTTPS Connect — IPv4 (most common on macOS/Linux)
-        try {
-            const agent = new https.Agent({ rejectUnauthorized: false });
-            const res = await fetch(`https://127.0.0.1:${port}/exa.language_server_pb.LanguageServerService/GetUserStatus`, {
-                method: 'POST', headers, body: '{}', signal: AbortSignal.timeout(3000), agent
-            });
-            if (res.ok) { console.log(`[✓] API on port ${port} (HTTPS/IPv4)`); return { port, useTls: true }; }
-        } catch { }
-
-        // 2. HTTP Connect — localhost (OS-dependent: may be IPv4 or IPv6)
-        try {
-            const res = await fetch(`http://localhost:${port}/exa.language_server_pb.LanguageServerService/GetUserStatus`, {
-                method: 'POST', headers, body: '{}', signal: AbortSignal.timeout(3000)
-            });
-            if (res.ok) { console.log(`[✓] API on port ${port} (HTTP/localhost)`); return { port, useTls: false }; }
-        } catch { }
-
-        // 3. HTTPS Connect — IPv6 loopback
-        // Fix #68: Windows 11 LS may bind ::1 instead of 127.0.0.1
-        try {
-            const agent = new https.Agent({ rejectUnauthorized: false });
-            const res = await fetch(`https://[::1]:${port}/exa.language_server_pb.LanguageServerService/GetUserStatus`, {
-                method: 'POST', headers, body: '{}', signal: AbortSignal.timeout(3000), agent
-            });
-            if (res.ok) { console.log(`[✓] API on port ${port} (HTTPS/IPv6)`); return { port, useTls: true }; }
-        } catch { }
-
-        // 4. HTTP Connect — IPv6 loopback
-        try {
-            const res = await fetch(`http://[::1]:${port}/exa.language_server_pb.LanguageServerService/GetUserStatus`, {
-                method: 'POST', headers, body: '{}', signal: AbortSignal.timeout(3000)
-            });
-            if (res.ok) { console.log(`[✓] API on port ${port} (HTTP/IPv6)`); return { port, useTls: false }; }
-        } catch { }
+        console.log(`[~] Probing port ${port} (${probes.length} strategies)...`);
+        for (const probe of probes) {
+            try {
+                const opts = { method: 'POST', headers, body: '{}', signal: AbortSignal.timeout(3000) };
+                if (probe.tls) opts.agent = new https.Agent({ rejectUnauthorized: false });
+                const res = await fetch(probe.url(port), opts);
+                if (res.ok) {
+                    console.log(`[✓] API on port ${port} (${probe.label})`);
+                    return { port, useTls: probe.tls };
+                }
+                console.log(`[~] Port ${port} ${probe.label}: responded ${res.status} ${res.statusText}`);
+            } catch (err) {
+                const reason = err?.cause?.code || err?.code || err?.message || String(err);
+                console.log(`[~] Port ${port} ${probe.label}: ${reason}`);
+            }
+        }
     }
     return null;
 }
@@ -258,7 +249,11 @@ async function init(onReady) {
     const seenFolderUris = new Set();
     for (const inst of instances) {
         const ports = await detectPorts(inst.pid);
-        if (!ports.length) continue;
+        if (!ports.length) {
+            console.log(`[!] PID ${inst.pid}: no listening ports found`);
+            continue;
+        }
+        console.log(`[~] PID ${inst.pid}: found ${ports.length} candidate port(s): ${ports.join(', ')}`);
 
         const result = await findApiPort(ports, inst.csrfToken);
         if (result) {

--- a/src/poller.js
+++ b/src/poller.js
@@ -182,13 +182,15 @@ async function pollNow() {
 
             // Poll conversations to keep cache up to date:
             // - RUNNING/WAITING: always poll (streaming content updates)
-            // - IDLE: poll if server has more steps than cache (catch up after transition)
+            // - IDLE: poll if server has more/fewer steps than cache (catch up after transition or rollback)
             const isRunning = info.status === 'CASCADE_RUN_STATUS_RUNNING' ||
                 info.status === 'CASCADE_RUN_STATUS_WAITING_FOR_USER';
             const cached = stepCache[cascadeId];
-            const serverAhead = cached && info.stepCount > (cached.baseIndex || 0) + cached.steps.length;
+            const cachedLen = cached ? (cached.baseIndex || 0) + cached.steps.length : 0;
+            const serverAhead = cached && info.stepCount > cachedLen;
+            const serverBehind = cached && info.stepCount < cachedLen;
 
-            if (isRunning || serverAhead) {
+            if (isRunning || serverAhead || serverBehind) {
                 await pollConversation(cascadeId, info);
             }
 

--- a/src/routes/cascade.js
+++ b/src/routes/cascade.js
@@ -27,6 +27,8 @@ const ALLOWED_LS_METHODS = new Set([
     'UninstallCascadePlugin',
     'StartCascadeInvocation',
     'SendCascadeMessage',
+    'GetRevertPreview',
+    'RevertToCascadeStep',
 ]);
 
 module.exports = function setupCascadeRoutes(app) {
@@ -238,6 +240,52 @@ module.exports = function setupCascadeRoutes(app) {
     app.delete('/api/plugins/:id', async (req, res) => {
         try { res.json(await callApi('UninstallCascadePlugin', { pluginId: req.params.id }, resolveInst(req))); }
         catch (e) { res.status(500).json({ error: e.message }); }
+    });
+
+    // Revert preview — show what rolling back to a step would do
+    app.post('/api/cascade/:id/revert-preview', async (req, res) => {
+        try {
+            const inst = resolveInst(req);
+            if (!inst) return res.status(503).json({ error: 'No language server connected' });
+            const result = await callApi('GetRevertPreview', {
+                cascadeId: req.params.id,
+                stepIndex: req.body.stepIndex,
+                metadata: {},
+                overrideConfig: {
+                    plannerConfig: {
+                        conversational: { plannerMode: 'CONVERSATIONAL_PLANNER_MODE_DEFAULT', agenticMode: true },
+                        requestedModel: { model: req.body.modelId || 'MODEL_PLACEHOLDER_M26' },
+                        ephemeralMessagesConfig: { enabled: true },
+                        knowledgeConfig: { enabled: true }
+                    },
+                    conversationHistoryConfig: { enabled: true }
+                }
+            }, inst);
+            res.json(result);
+        } catch (e) { res.status(500).json({ error: e.message }); }
+    });
+
+    // Revert cascade to a specific step (rollback)
+    app.post('/api/cascade/:id/revert', async (req, res) => {
+        try {
+            const inst = resolveInst(req);
+            if (!inst) return res.status(503).json({ error: 'No language server connected' });
+            const result = await callApi('RevertToCascadeStep', {
+                cascadeId: req.params.id,
+                stepIndex: req.body.stepIndex,
+                metadata: {},
+                overrideConfig: {
+                    plannerConfig: {
+                        conversational: { plannerMode: 'CONVERSATIONAL_PLANNER_MODE_DEFAULT', agenticMode: true },
+                        requestedModel: { model: req.body.modelId || 'MODEL_PLACEHOLDER_M26' },
+                        ephemeralMessagesConfig: { enabled: true },
+                        knowledgeConfig: { enabled: true }
+                    },
+                    conversationHistoryConfig: { enabled: true }
+                }
+            }, inst);
+            res.json(result);
+        } catch (e) { res.status(500).json({ error: e.message }); }
     });
 
     // === Generic LS Proxy — call any method ===


### PR DESCRIPTION
## Summary
- Add 2 new backend routes: `POST /api/cascade/:id/revert-preview` and `POST /api/cascade/:id/revert` for GetRevertPreview and RevertToCascadeStep LS APIs
- Fix poller bug: `serverAhead` only detected step count increases — after rollback (step count decreases), poller skipped re-fetch, leaving UI stale
- Add rollback button (RotateCcw icon) to user messages with inline "Confirm?" confirmation
- Disabled when cascade is running/waiting, auto-dismisses after 3s

Addresses #85 (rollback to checkpoint)

## Files changed
- `src/routes/cascade.js` — whitelist + 2 new routes with `overrideConfig` payload matching Antigravity IDE curl
- `src/poller.js` — add `serverBehind` check for step count decreases
- `frontend/lib/cascade-api.ts` — `cascadeRevertPreview()` and `cascadeRevert()` API functions
- `frontend/components/chat/user-message.tsx` — rollback button with inline confirmation UX
- `frontend/components/chat-view.tsx` — `handleRollback` handler, wired to UserMessage

## Test plan
- [ ] Open conversation with multiple user messages
- [ ] Hover user message → rollback icon visible
- [ ] Click rollback → "Confirm?" appears, auto-dismisses after 3s
- [ ] Confirm rollback → steps after that point removed
- [ ] Verify poller detects step decrease and re-syncs UI
- [ ] Test while cascade running → button disabled
- [ ] Verify TypeScript compiles with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)