### PR TITLE
feat: ngrok fallback tunnel for remote mobile access

### DIFF
--- a/docs/NGROK-REMOTE-ACCESS.md
+++ b/docs/NGROK-REMOTE-ACCESS.md
@@ -1,0 +1,598 @@
+# Ngrok Remote Access — Complete Guide
+
+> **Purpose**: Access Antigravity Deck from any device (phone, tablet, another laptop) over the internet using ngrok as a secure tunnel provider.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Architecture](#architecture)
+3. [Prerequisites](#prerequisites)
+4. [Quick Start](#quick-start)
+5. [How It Works — Deep Dive](#how-it-works--deep-dive)
+6. [Configuration Reference](#configuration-reference)
+7. [Mobile-Specific Behavior](#mobile-specific-behavior)
+8. [Troubleshooting](#troubleshooting)
+9. [Security Model](#security-model)
+10. [Provider Comparison: Cloudflared vs Ngrok](#provider-comparison-cloudflared-vs-ngrok)
+11. [Files Modified](#files-modified)
+12. [Known Limitations](#known-limitations)
+
+---
+
+## Overview
+
+Antigravity Deck supports two tunnel providers for remote access:
+
+| Provider      | Priority | Account Required | Tunnels Used | Best For                    |
+|---------------|----------|------------------|--------------|-----------------------------|
+| **cloudflared** | 1st (default) | No (anonymous)  | 2 (BE + FE)  | Zero-setup, dual-tunnel     |
+| **ngrok**       | 2nd (fallback) | Yes (free tier) | 1 (FE only)  | When cloudflared unavailable |
+
+The system auto-detects which provider is installed. If both are present, cloudflared is preferred unless `--ngrok` is passed.
+
+### Why ngrok as a fallback?
+
+Cloudflare's Quick Tunnels are anonymous and ephemeral but can hit aggressive rate limits (HTTP 429 / error 1015) after repeated restarts. When this happens, ngrok provides immediate, reliable fallback access with a free-tier account.
+
+---
+
+## Architecture
+
+### Cloudflared Mode (Dual Tunnel)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      Your Machine (localhost)                    │
+│                                                                 │
+│  ┌──────────┐       ┌──────────┐                               │
+│  │ Backend  │:9807  │ Frontend │:9808                           │
+│  │ Express  │◄──────│ Next.js  │                               │
+│  │ server.js│       │          │                               │
+│  └────┬─────┘       └─────┬────┘                               │
+│       │                   │                                     │
+└───────┼───────────────────┼─────────────────────────────────────┘
+        │                   │
+   ┌────┴────┐         ┌────┴────┐
+   │Cloudflare│        │Cloudflare│
+   │Tunnel BE │        │Tunnel FE │
+   └────┬────┘         └────┬────┘
+        │                   │
+   https://xxx-yyy       https://aaa-bbb
+   .trycloudflare.com   .trycloudflare.com
+                   ▲
+                   │
+              📱 Mobile
+```
+
+**Flow**: Two independent tunnels. Frontend build bakes the backend tunnel URL into `NEXT_PUBLIC_BACKEND_URL` at compile time. WebSocket connects directly to backend tunnel.
+
+### Ngrok Mode (Single Tunnel) ← New
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                      Your Machine (localhost)                     │
+│                                                                  │
+│  ┌──────────┐  localhost:9807  ┌──────────────┐                 │
+│  │ Backend  │◄────────────────│   Frontend    │:9808            │
+│  │ Express  │  (Next.js proxy  │   Next.js     │                │
+│  │ server.js│   /api/* → BE)   │ next.config.ts│                │
+│  │          │  (/ws/* → BE)    │               │                │
+│  └──────────┘                  └───────┬───────┘                │
+│                                        │                         │
+└────────────────────────────────────────┼─────────────────────────┘
+                                         │
+                                    ┌────┴────┐
+                                    │  ngrok  │
+                                    │ Tunnel  │
+                                    └────┬────┘
+                                         │
+                                 https://xxxx-yy-zz
+                                 .ngrok-free.app
+                                         ▲
+                                         │
+                                    📱 Mobile
+```
+
+**Flow**: Single tunnel to frontend port 9808. Next.js reverse-proxy forwards:
+- `/api/*` → `http://localhost:9807/api/*` (HTTP REST)
+- `/ws/*` → `http://localhost:9807/ws/*` (WebSocket upgrade)
+
+The backend never needs its own tunnel. It sets `ALLOW_LOCALHOST_BYPASS=true` to accept unauthenticated requests from the Next.js proxy on localhost.
+
+---
+
+## Prerequisites
+
+### 1. Install ngrok
+
+**Windows (winget):**
+```powershell
+winget install ngrok.ngrok
+```
+
+**Windows (manual):**
+1. Download from https://ngrok.com/download
+2. Extract `ngrok.exe` to your PATH or user profile
+
+**macOS:**
+```bash
+brew install ngrok
+```
+
+**Linux:**
+```bash
+sudo snap install ngrok   # or download from ngrok.com
+```
+
+### 2. Create a Free Account & Configure Auth Token
+
+1. Sign up at https://dashboard.ngrok.com/signup (free)
+2. Copy your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
+3. Run:
+
+```bash
+ngrok config add-authtoken YOUR_TOKEN_HERE
+```
+
+This is a **one-time setup** — the token persists in ngrok's config file.
+
+### 3. Verify Installation
+
+```bash
+ngrok version
+# ngrok version 3.x.x
+```
+
+---
+
+## Quick Start
+
+### Option A: Auto-detect (recommended)
+
+```bash
+npm run online
+```
+
+This detects available providers in order: cloudflared → ngrok → error.
+
+### Option B: Force ngrok
+
+```bash
+npm run online:ngrok
+```
+
+Forces ngrok even if cloudflared is installed.
+
+### What Happens
+
+1. Backend starts on `localhost:9807`
+2. Frontend builds (if needed) and starts on `localhost:9808`
+3. Ngrok tunnel opens to port 9808
+4. Terminal displays:
+   - 🌐 Public URL (e.g., `https://xxxx-yy-zz.ngrok-free.app`)
+   - 🔑 Auth Key (32-char hex string)
+   - 📱 QR code (auto-login URL with key embedded)
+5. Tunnel info written to `.tunnel-info.txt`
+
+### Connect from Mobile
+
+**Method 1 — QR Code (fastest):**
+Scan the QR code displayed in your terminal. The URL includes the auth key so you're logged in automatically.
+
+**Method 2 — Manual URL:**
+1. Open the ngrok URL in your mobile browser
+2. On first visit, ngrok shows a "Visit Site" interstitial — tap through
+3. Enter the auth key when prompted (or append `?key=YOUR_KEY` to the URL)
+
+### Stop
+
+Press `Ctrl+C` in the terminal. All processes (backend, frontend, ngrok) are cleaned up automatically.
+
+---
+
+## How It Works — Deep Dive
+
+### Startup Sequence (`start-tunnel.js`)
+
+```
+1. Kill stale processes on ports 9807, 9808
+2. Generate random AUTH_KEY (or use AUTH_KEY env var)
+3. Start backend:
+     node server.js
+     env: PORT=9807, AUTH_KEY=<key>, ALLOW_LOCALHOST_BYPASS=true, NODE_ENV=production
+4. Wait 3 seconds for backend to initialize
+5. Check if frontend build is needed:
+     - Missing .next directory? → rebuild
+     - .next/.backend-port doesn't match 9807? → rebuild
+     - --build flag? → rebuild
+6. Build frontend (if needed):
+     npx next build
+     env: BACKEND_PORT=9807
+7. Start frontend:
+     npx next start --port 9808
+     env: BACKEND_PORT=9807, NODE_ENV=production
+8. Wait 3 seconds for frontend to initialize
+9. Start ngrok tunnel:
+     ngrok http 9808 --log stdout
+10. Parse tunnel URL from ngrok stdout
+11. Display URL, QR code, write .tunnel-info.txt
+12. Keep running until Ctrl+C
+```
+
+### Next.js Reverse Proxy (`frontend/next.config.ts`)
+
+The frontend's `rewrites()` configuration is the linchpin of single-tunnel mode:
+
+```typescript
+async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `http://localhost:${BE_PORT}/api/:path*`,
+      },
+      {
+        source: '/ws/:path*',
+        destination: `http://localhost:${BE_PORT}/ws/:path*`,
+      },
+    ];
+  },
+```
+
+- **`/api/*`**: All REST API calls from the browser → Next.js → backend. This includes conversation CRUD, workspace management, step fetching, cascade control, etc.
+- **`/ws/*`**: WebSocket upgrade requests from the browser → Next.js → backend. This enables real-time streaming of AI responses, status updates, and live workspace monitoring.
+
+### WebSocket Routing (`server.js`)
+
+The backend Express server handles WebSocket upgrades on four explicit paths:
+
+```javascript
+server.on('upgrade', (req, socket, head) => {
+  const { pathname } = new URL(req.url, 'http://localhost');
+  if (pathname === '/ws/orchestrator') { /* orchestrator WS */ }
+  else if (pathname === '/ws/agent')   { /* agent WS */ }
+  else if (pathname === '/ws/ui' || pathname === '/') { /* UI WS */ }
+  else { socket.destroy(); }
+});
+```
+
+The frontend `ws-service.ts` connects to `/ws/ui` which Next.js proxies to the backend.
+
+### Auth Flow (`frontend/lib/auth.ts`)
+
+```
+1. User opens ngrok URL with ?key=<auth_key>
+2. Frontend extracts key from URL query parameter
+3. Key stored in BOTH:
+   - localStorage ('antigravity_auth_key')
+   - Cookie ('ag_auth_key', 30-day expiry, SameSite=Strict)
+4. All API requests include X-Auth-Key header
+5. WebSocket URL includes ?auth_key=<key> query param
+```
+
+**Why dual storage?** Mobile browsers (especially iOS Safari) can purge localStorage when killing background tabs under memory pressure. Cookies survive this, so the auth key is always recoverable.
+
+### Localhost Bypass (`ALLOW_LOCALHOST_BYPASS`)
+
+When ngrok mode is active, the backend environment includes `ALLOW_LOCALHOST_BYPASS=true`. This tells the backend auth middleware:
+
+> "If the request comes from 127.0.0.1 / localhost, skip auth key validation."
+
+This is necessary because Next.js proxy requests appear to originate from localhost, but they don't carry the `X-Auth-Key` header (that's a browser-to-Next.js concern, not a Next.js-to-backend concern). Without this bypass, every proxied API call would return 401 Unauthorized.
+
+### WebSocket URL Resolution (`frontend/lib/config.ts`)
+
+The frontend resolves the WebSocket URL at runtime (not build time):
+
+```typescript
+async function _resolveWsUrl(): Promise<string> {
+    const isLocal = hostname === 'localhost' || ...;
+
+    // Always try /api/ws-url first
+    const { wsPort } = await fetch('/api/ws-url').then(r => r.json());
+
+    if (isLocal) {
+        return `ws://${hostname}:${wsPort}`;  // Direct to backend
+    }
+
+    // Remote: try same host (works if WS upgrade is supported)
+    return `${protocol}://${window.location.host}`;
+}
+```
+
+For ngrok mode, the WS URL resolves to `wss://xxxx.ngrok-free.app`, and the `ws-service.ts` appends `/ws/ui` to get `wss://xxxx.ngrok-free.app/ws/ui`. This is proxied by Next.js rewrites to `http://localhost:9807/ws/ui`.
+
+### State Persistence for Mobile Resume
+
+Mobile browsers aggressively kill background tabs. When the user returns to the app:
+
+1. **Cached detected state**: `localStorage('antigravity-cached-detected')` — prevents flash of "Launch Antigravity" onboarding screen
+2. **Cached steps**: Last 30 conversation steps cached in localStorage — instant content display before WS reconnects
+3. **Cached WS URL**: `localStorage('antigravity-ws-url')` — no HTTP round-trip needed on cold reload
+4. **Grace period**: 5-second reconnect grace suppresses disconnect indicators after mount
+
+### Headless Language Server (`src/headless-ls.js`)
+
+When connecting remotely, the user can't launch the Antigravity IDE GUI. Instead, the backend spawns a **headless Language Server** process:
+
+```
+1. Detect LS binary from running IDE process or known install paths
+2. Get extension server auth (port + CSRF) from running IDE
+3. Create mock parent pipe (Windows named pipe / Unix socket)
+4. Spawn LS with args:
+     --enable_lsp
+     --csrf_token <random>
+     --workspace_id <encoded_path>
+     --parent_pipe_path <pipe>
+     --extension_server_port <port>
+     --extension_server_csrf_token <token>
+5. Wait for LS to bind HTTP/HTTPS ports
+6. Call AddTrackedWorkspace API to bind workspace folder
+7. Register in lsInstances array
+8. Frontend sees new workspace via conversations_updated broadcast
+```
+
+**Important**: The headless LS requires at least one Antigravity IDE window to be open on the host machine (for extension server auth). It cannot run standalone.
+
+---
+
+## Configuration Reference
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTH_KEY` | Random 32-hex | Override the generated auth key |
+| `ALLOW_LOCALHOST_BYPASS` | `false` | Skip auth for localhost requests (set automatically in ngrok mode) |
+| `BACKEND_PORT` | `9807` (prod) / `3500` (dev) | Backend port |
+| `QUIET_POLL` | `0` | Suppress LS polling logs |
+| `NODE_ENV` | — | Set to `production` by tunnel launcher |
+
+### CLI Flags (`start-tunnel.js`)
+
+| Flag | Description |
+|------|-------------|
+| `--ngrok` | Force ngrok even if cloudflared is available |
+| `--local` | No tunnels — local-only mode |
+| `--build` | Force frontend rebuild (even if `.next` exists) |
+| `--quiet` | Minimal output |
+
+### NPM Scripts
+
+| Script | Command | Description |
+|--------|---------|-------------|
+| `npm run online` | `node start-tunnel.js` | Auto-detect provider (cloudflared → ngrok) |
+| `npm run online:ngrok` | `node start-tunnel.js --ngrok` | Force ngrok |
+| `npm run prod` | `node start-tunnel.js --local` | Local production (no tunnel) |
+| `npm run dev` | `concurrently BE FE` | Development mode (ports 3500/3000) |
+
+### Ports
+
+| Port | Service | Notes |
+|------|---------|-------|
+| `9807` | Backend (Express) | Production only — dev uses 3500 |
+| `9808` | Frontend (Next.js) | Production only — dev uses 3000 |
+| `3500` | Backend (dev) | Used during `npm run dev` |
+| `3000` | Frontend (dev) | Used during `npm run dev` |
+
+### Output Files
+
+| File | Description |
+|------|-------------|
+| `.tunnel-info.txt` | Active tunnel URL, auth key, timestamps |
+| `frontend/.next/.backend-port` | Port marker to detect stale builds |
+
+---
+
+## Mobile-Specific Behavior
+
+### Sidebar Auto-Close
+
+On mobile devices (screen width < 768px), the sidebar drawer auto-closes when the user:
+- Selects a workspace
+- Opens a conversation
+- Clicks a navigation item (Settings, Agent Hub, etc.)
+- Creates a new workspace
+
+This is handled by the `closeMobile()` helper in `app-sidebar.tsx`:
+
+```typescript
+const closeMobile = useCallback(() => {
+    if (isMobile) setOpenMobile(false)
+}, [isMobile, setOpenMobile])
+```
+
+### Page Lifecycle Events
+
+The WebSocket service handles mobile browser lifecycle events:
+
+- **`visibilitychange` → hidden**: Records timestamp
+- **`visibilitychange` → visible**: If hidden > 5s, force-reconnects (assumes WS is stale)
+- **`freeze`** (iOS/mobile): Clean-closes WS to avoid stuck CLOSING state
+- **`resume`**: Immediately reconnects
+
+### PWA Considerations
+
+The app includes a service worker and PWA manifest. On mobile:
+- Add to Home Screen for native-app feel
+- Push notifications work via VAPID keys
+- Offline state shows cached content gracefully
+
+---
+
+## Troubleshooting
+
+### "LS Connected" green but chatbox empty
+
+**Cause**: WebSocket connection failed — the AI response stream can't reach the browser.
+
+**Fix**: Ensure `next.config.ts` has the `/ws/*` rewrite rule and the build includes it. Force rebuild:
+```bash
+npm run online:ngrok -- --build
+```
+
+### "WS" indicator shows red
+
+**Cause**: WebSocket upgrade rejected by ngrok or Next.js.
+
+**Check**:
+1. `frontend/next.config.ts` must have both `/api/*` and `/ws/*` rewrites
+2. `server.js` must accept `/ws/ui` path in upgrade handler
+3. Rebuild frontend after config changes
+
+### Workspace shows orange HL badge
+
+**Cause**: Successfully launched a headless Language Server. Orange = headless (vs blue = IDE).
+
+This is normal and expected when connecting remotely.
+
+### "Headless LS failed to bind ports within timeout"
+
+**Cause**: The Language Server binary crashed on startup — usually a bad flag.
+
+**Check**:
+- `src/headless-ls.js` should NOT pass `--random_port` (removed — was a deprecated flag)
+- At least one Antigravity IDE window must be open (provides extension server auth)
+- Verify the LS binary exists at the detected path
+
+### ngrok shows "ERR_NGROK_105" or "authtoken invalid"
+
+**Fix**: Configure your authtoken:
+```bash
+ngrok config add-authtoken YOUR_TOKEN
+```
+
+### Process crashes with "exit code: 1" on restart
+
+**Cause**: Port contention from previous run's zombie processes.
+
+**Fix**: The launcher automatically kills stale processes on ports 9807/9808 at startup. If it still fails:
+```powershell
+# Windows
+taskkill /F /FI "IMAGENAME eq node.exe"
+taskkill /F /FI "IMAGENAME eq ngrok.exe"
+
+# macOS/Linux
+lsof -ti :9807 :9808 | xargs kill -9
+pkill -f "ngrok.*http"
+```
+
+### Cloudflare rate limited (429)
+
+Switch to ngrok:
+```bash
+npm run online:ngrok
+```
+
+Or wait 5-10 minutes and retry `npm run online`.
+
+### Mobile shows "Launch Antigravity" loop
+
+**Cause**: The `detected` state is false because neither WebSocket nor HTTP polling confirmed an LS instance.
+
+**Check**:
+1. Backend is running and healthy: `curl http://localhost:9807/api/status`
+2. At least one workspace is open in the IDE on the host machine
+3. The `detected` state is NOT reset on WS close (check `websocket.ts` line 157)
+
+---
+
+## Security Model
+
+### Authentication
+
+- **Auth Key**: 32-character random hex generated per session
+- **Transport**: HTTPS (ngrok provides TLS termination)
+- **Header**: `X-Auth-Key` on all HTTP requests
+- **WebSocket**: `?auth_key=<key>` query parameter
+- **Storage**: localStorage + cookie (dual redundancy for mobile)
+- **Cookie**: `SameSite=Strict`, 30-day expiry
+
+### Localhost Bypass
+
+When `ALLOW_LOCALHOST_BYPASS=true`, requests from `127.0.0.1` skip auth validation. This is ONLY set in ngrok mode where Next.js proxies requests from the browser through localhost.
+
+### Network Exposure
+
+- Backend port 9807 is **never exposed** to the internet in ngrok mode
+- Only port 9808 (frontend) is tunneled
+- All backend communication goes through the Next.js reverse proxy on localhost
+- Ngrok provides TLS encryption for the public-facing connection
+
+### Helmet.js Headers
+
+The Express backend applies security headers via Helmet:
+- Content Security Policy (CSP)
+- HSTS (1 year, includeSubDomains, preload)
+- X-Frame-Options: DENY
+- X-Content-Type-Options: nosniff
+- Referrer-Policy: strict-origin-when-cross-origin
+
+### Rate Limiting
+
+Express applies `express-rate-limit` to prevent brute-force auth key guessing.
+
+---
+
+## Provider Comparison: Cloudflared vs Ngrok
+
+| Aspect | Cloudflared | Ngrok |
+|--------|------------|-------|
+| **Account** | None (anonymous) | Free account required |
+| **Setup** | `winget install cloudflare.cloudflared` | `winget install ngrok.ngrok` + authtoken |
+| **Tunnels** | 2 (BE + FE) | 1 (FE only) |
+| **Build** | Required per session (bakes BE URL) | Cached (no URL baking needed) |
+| **Startup Time** | ~30-60s (includes rebuild) | ~15-30s (reuses cached build) |
+| **URL Format** | `https://xxx-yyy.trycloudflare.com` | `https://xxxx.ngrok-free.app` |
+| **URL Stability** | New URL every restart | New URL every restart (free tier) |
+| **Rate Limits** | Aggressive (429 after ~10 restarts) | Generous (free: 1 tunnel, 20 conn/min) |
+| **WebSocket** | Direct to backend tunnel | Via Next.js proxy |
+| **Interstitial** | None | "Visit Site" page on first visit |
+| **CLI** | `cloudflared tunnel --url ...` | `ngrok http PORT --log stdout` |
+
+### When to Use Each
+
+- **cloudflared**: First choice. No account, no interstitial page. Just works.
+- **ngrok**: When cloudflared is rate-limited or unavailable. Requires one-time account setup.
+
+---
+
+## Files Modified
+
+### Core Changes for Ngrok Support
+
+| File | What Changed |
+|------|-------------|
+| [`start-tunnel.js`](../start-tunnel.js) | Added `findNgrok()`, provider abstraction, `_runNgrokTunnel()`, `ALLOW_LOCALHOST_BYPASS` env, ngrok URL extraction, ngrok rate-limit/auth detection |
+| [`server.js`](../server.js) | Added `/ws/ui` path to WebSocket upgrade handler |
+| [`frontend/next.config.ts`](../frontend/next.config.ts) | Added `/ws/:path*` rewrite rule for WebSocket proxying |
+| [`frontend/lib/ws-service.ts`](../frontend/lib/ws-service.ts) | Changed WS connection to use explicit `/ws/ui` path |
+| [`frontend/lib/config.ts`](../frontend/lib/config.ts) | Updated `getWsUrl()` to resolve via `/api/ws-url` first; localStorage caching |
+| [`frontend/lib/websocket.ts`](../frontend/lib/websocket.ts) | Prevented `detected` state reset on WS close; added cached state restore |
+| [`frontend/lib/auth.ts`](../frontend/lib/auth.ts) | Dual localStorage + cookie storage for auth key resilience |
+| [`frontend/components/app-sidebar.tsx`](../frontend/components/app-sidebar.tsx) | Added `closeMobile()` for auto-close on navigation |
+| [`src/headless-ls.js`](../src/headless-ls.js) | Removed deprecated `--random_port` flag |
+| [`package.json`](../package.json) | Added `online:ngrok` script |
+| [`scripts/setup.ps1`](../scripts/setup.ps1) | Added ngrok detection in dependency check |
+| [`scripts/setup.sh`](../scripts/setup.sh) | Added ngrok detection in dependency check |
+| [`scripts/uninstall.ps1`](../scripts/uninstall.ps1) | Added `ngrok.exe` to cleanup kill list |
+
+---
+
+## Known Limitations
+
+1. **Free-tier URL changes**: ngrok free tier generates a new URL on every restart. Consider ngrok paid plans for stable custom domains.
+
+2. **Interstitial page**: ngrok free tier shows a "Visit Site" interstitial on first visit per session. Users must tap through it.
+
+3. **One tunnel limit**: ngrok free tier allows only one tunnel at a time. The single-tunnel architecture (FE only) works within this constraint.
+
+4. **Auth key per session**: The auth key is regenerated on each `npm run online:ngrok` restart. Set `AUTH_KEY` environment variable for persistence:
+   ```bash
+   AUTH_KEY=my_fixed_key_here npm run online:ngrok
+   ```
+
+5. **Headless LS requires IDE**: The headless Language Server cannot authorize without at least one Antigravity IDE window running on the host machine.
+
+6. **WebSocket via proxy**: In ngrok mode, WebSocket connections go through Next.js's reverse proxy, adding marginal latency compared to cloudflared's direct backend tunnel. This is unnoticeable in practice.

--- a/frontend/components/app-sidebar.tsx
+++ b/frontend/components/app-sidebar.tsx
@@ -95,7 +95,11 @@ export function AppSidebar({
     onConvDeleted,
 }: AppSidebarProps) {
     const { isDark, toggle: toggleTheme } = useTheme()
-    const { isMobile } = useSidebar()
+    const { isMobile, setOpenMobile } = useSidebar()
+
+    const closeMobile = useCallback(() => {
+        if (isMobile) setOpenMobile(false)
+    }, [isMobile, setOpenMobile])
 
     const [wsData, setWsData] = useState<WorkspaceData[]>([])
     const [folders, setFolders] = useState<WorkspaceFolder[]>([])
@@ -265,8 +269,9 @@ export function AppSidebar({
                 return { ...d, expanded: !d.expanded }
             }))
             onSelectWorkspace(wd.workspace.workspaceName)
+            closeMobile()
         },
-        [wsData, onSelectWorkspace]
+        [wsData, onSelectWorkspace, closeMobile]
     )
 
     const handleSelectConv = useCallback(
@@ -274,8 +279,9 @@ export function AppSidebar({
             const wd = wsData[arrayIdx]
             if (!wd) return
             onSelectConversation(convId, wd.workspace.workspaceName)
+            closeMobile()
         },
-        [wsData, onSelectConversation]
+        [wsData, onSelectConversation, closeMobile]
     )
 
     // Called by WorkspaceGroup after a conversation is successfully deleted.
@@ -371,7 +377,7 @@ export function AppSidebar({
             <Sidebar variant="inset">
                 <SidebarHeader>
                     <button
-                        onClick={onGoHome}
+                        onClick={() => { onGoHome(); closeMobile(); }}
                         className="flex items-center gap-2 px-4 py-2 mt-2 hover:opacity-80 transition-opacity cursor-pointer"
                     >
                         <FolderSync className="h-5 w-5 text-primary" />
@@ -492,21 +498,21 @@ export function AppSidebar({
                         <SidebarGroupContent>
                             <SidebarMenu>
                                 <SidebarMenuItem>
-                                    <SidebarMenuButton onClick={onShowAgentHub} tooltip="Agent Hub" className="text-xs">
+                                    <SidebarMenuButton onClick={() => { onShowAgentHub(); closeMobile(); }} tooltip="Agent Hub" className="text-xs">
                                         <Bot className="shrink-0" />
                                         <span>Agent Hub</span>
                                     </SidebarMenuButton>
                                 </SidebarMenuItem>
                                 {/* Orchestrator hidden while chat-first redesign is in progress
                                 <SidebarMenuItem>
-                                    <SidebarMenuButton onClick={onShowOrchestrator} tooltip="Orchestrator" className="text-xs">
+                                    <SidebarMenuButton onClick={() => { onShowOrchestrator(); closeMobile(); }} tooltip="Orchestrator" className="text-xs">
                                         <Workflow className="shrink-0" />
                                         <span>Orchestrator</span>
                                     </SidebarMenuButton>
                                 </SidebarMenuItem>
                                 */}
                                 <SidebarMenuItem>
-                                    <SidebarMenuButton onClick={onShowConnect} tooltip="Connect" className="text-xs">
+                                    <SidebarMenuButton onClick={() => { onShowConnect(); closeMobile(); }} tooltip="Connect" className="text-xs">
                                         <Cable className="shrink-0" />
                                         <span>Connect</span>
                                     </SidebarMenuButton>
@@ -553,19 +559,19 @@ export function AppSidebar({
                                     sideOffset={4}
                                     className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
                                 >
-                                    <DropdownMenuItem onClick={onShowAccountInfo}>
+                                    <DropdownMenuItem onClick={() => { onShowAccountInfo(); closeMobile(); }}>
                                         <User className="mr-2 h-4 w-4" />
                                         <span>Account & Plan</span>
                                     </DropdownMenuItem>
-                                    <DropdownMenuItem onClick={onShowLogs}>
+                                    <DropdownMenuItem onClick={() => { onShowLogs(); closeMobile(); }}>
                                         <Activity className="mr-2 h-4 w-4" />
                                         <span>Live Logs</span>
                                     </DropdownMenuItem>
-                                    <DropdownMenuItem onClick={onShowSourceControl}>
+                                    <DropdownMenuItem onClick={() => { onShowSourceControl(); closeMobile(); }}>
                                         <GitBranch className="mr-2 h-4 w-4" />
                                         <span>Source Control</span>
                                     </DropdownMenuItem>
-                                    <DropdownMenuItem onClick={onShowResources}>
+                                    <DropdownMenuItem onClick={() => { onShowResources(); closeMobile(); }}>
                                         <Monitor className="mr-2 h-4 w-4" />
                                         <span>Resources</span>
                                     </DropdownMenuItem>
@@ -574,7 +580,7 @@ export function AppSidebar({
                                         <span>{isDark ? "Light Mode" : "Dark Mode"}</span>
                                     </DropdownMenuItem>
                                     <DropdownMenuSeparator />
-                                    <DropdownMenuItem onClick={() => setShowPlugins(true)}>
+                                    <DropdownMenuItem onClick={() => { setShowPlugins(true); closeMobile(); }}>
                                         <Plug className="mr-2 h-4 w-4" />
                                         <span>Plugins</span>
                                     </DropdownMenuItem>
@@ -587,7 +593,7 @@ export function AppSidebar({
                                         <span className="text-muted-foreground">Browser (Coming Soon)</span>
                                     </DropdownMenuItem>
                                     <DropdownMenuSeparator />
-                                    <DropdownMenuItem onClick={onShowSettings}>
+                                    <DropdownMenuItem onClick={() => { onShowSettings(); closeMobile(); }}>
                                         <Settings className="mr-2 h-4 w-4" />
                                         <span>App Settings</span>
                                     </DropdownMenuItem>

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -33,6 +33,7 @@ export async function getWsUrl(): Promise<string> {
 
 async function _resolveWsUrl(): Promise<string> {
     const hostname = window.location.hostname;
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
 
     const isLocal =
         hostname === 'localhost' ||
@@ -42,19 +43,31 @@ async function _resolveWsUrl(): Promise<string> {
         /^172\.(1[6-9]|2\d|3[01])\./.test(hostname) ||
         /^169\.254\./.test(hostname);
 
-    if (isLocal) {
-        try {
-            const res = await fetch('/api/ws-url');
-            const { wsPort } = await res.json();
+    // Always try /api/ws-url first — works through Next.js proxy for all modes
+    try {
+        const res = await fetch('/api/ws-url');
+        const { wsPort } = await res.json();
+
+        if (isLocal) {
+            // Local: connect directly to backend port on same host
             return `ws://${hostname}:${wsPort}`;
-        } catch {
-            return `ws://${hostname}:3500`;
         }
-    } else {
+
+        // Remote (ngrok/cloudflare): backend WS port is not directly accessible.
+        // If NEXT_PUBLIC_BACKEND_URL was baked in (cloudflared mode), use it.
         const tunnel = process.env.NEXT_PUBLIC_BACKEND_URL || '';
-        return tunnel
-            ? tunnel.replace(/^http/, 'ws')
-            : `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`;
+        if (tunnel) {
+            return tunnel.replace(/^http/, 'ws');
+        }
+
+        // ngrok single-tunnel mode: WS is not accessible through FE tunnel.
+        // Fall back to polling mode by returning an unreachable URL that will
+        // gracefully fail, and the UI will still work via HTTP polling.
+        // Actually — try the same host first; if ngrok supports WS upgrade, it works.
+        return `${protocol}://${window.location.host}`;
+    } catch {
+        if (isLocal) return `ws://${hostname}:3500`;
+        return `${protocol}://${window.location.host}`;
     }
 }
 

--- a/frontend/lib/websocket.ts
+++ b/frontend/lib/websocket.ts
@@ -152,7 +152,9 @@ export function useWebSocket() {
                 return;
             }
             graceActiveRef.current = false;
-            setState(prev => ({ ...prev, connected: false, detected: false }));
+            // Don't reset detected — HTTP polling fallback handles LS detection independently.
+            // Resetting it here causes a back-and-forth loop when WS can't connect (e.g. ngrok tunnel).
+            setState(prev => ({ ...prev, connected: false }));
         });
 
         const offStatus = wsService.on('status', (data) => {

--- a/frontend/lib/ws-service.ts
+++ b/frontend/lib/ws-service.ts
@@ -97,7 +97,8 @@ class WebSocketService {
         }
         try {
             const wsBase = await getWsUrl();
-            const ws = new WebSocket(authWsUrl(wsBase));
+            const wsUrl = wsBase.replace(/\/$/, '') + '/ws/ui';
+            const ws = new WebSocket(authWsUrl(wsUrl));
             this.ws = ws;
 
             ws.onopen = () => {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,6 +26,10 @@ const nextConfig: NextConfig = {
         source: '/api/:path*',
         destination: `${BE_HOST}/api/:path*`,
       },
+      {
+        source: '/ws/:path*',
+        destination: `${BE_HOST}/ws/:path*`,
+      },
     ];
   },
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3000",
+    "dev": "next dev -p 1234",
     "build": "next build",
     "start": "next start",
     "lint": "eslint"

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
     "prod": "node start-tunnel.js --local",
     "server": "node --watch server.js --port 3500",
     "tunnel:be": "cloudflared tunnel --url http://localhost:3500",
-    "tunnel:fe": "cloudflared tunnel --url http://localhost:3000",
+    "tunnel:fe": "cloudflared tunnel --url http://localhost:1234",
     "tunnel": "npx concurrently -n TUN-BE,TUN-FE -c green,yellow \"npm run tunnel:be\" \"npm run tunnel:fe\"",
-    "online": "node start-tunnel.js"
+    "online": "node start-tunnel.js",
+    "online:ngrok": "node start-tunnel.js --ngrok"
   },
   "dependencies": {
     "discord.js": "^14.25.1",

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -91,6 +91,23 @@ else {
     Write-Host "  [!] cloudflared not found (optional, needed for remote access)" -ForegroundColor Yellow
 }
 
+# ngrok (optional fallback -- needed if cloudflared unavailable)
+$ngFound = $false
+try {
+    ngrok version 2>$null | Out-Null
+    $ngFound = $true
+}
+catch { }
+
+if ($ngFound) {
+    Write-Host "  [OK] ngrok" -ForegroundColor Green
+}
+else {
+    if (-not $cfFound) {
+        Write-Host "  [!] ngrok not found (optional, needed for remote access)" -ForegroundColor Yellow
+    }
+}
+
 if ($missing.Count -gt 0) {
     Write-Host ""
     Write-Host "  Missing prerequisites:" -ForegroundColor Red
@@ -257,7 +274,7 @@ Write-Host ""
 Write-Host "  Starting Antigravity Deck..." -ForegroundColor Green
 Write-Host ""
 
-if ($cfFound) {
+if ($cfFound -or $ngFound) {
     node start-tunnel.js --quiet --build
 } else {
     node start-tunnel.js --local --build

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -73,6 +73,20 @@ else
     echo "  ⚠️  cloudflared not found (optional — needed for remote access)"
 fi
 
+# ngrok (optional fallback — needed if cloudflared unavailable)
+ng_found=false
+if command -v ngrok &>/dev/null; then
+    ng_found=true
+fi
+
+if $ng_found; then
+    echo "  ✅ ngrok"
+else
+    if ! $cf_found; then
+        echo "  ⚠️  ngrok not found (optional — needed for remote access)"
+    fi
+fi
+
 if [ ${#missing[@]} -gt 0 ]; then
     echo ""
     echo "  Missing prerequisites:"
@@ -216,7 +230,7 @@ echo ""
 echo "  Starting Antigravity Deck..."
 echo ""
 
-if $cf_found; then
+if $cf_found || $ng_found; then
     node start-tunnel.js --quiet --build
 else
     node start-tunnel.js --local --build

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -36,7 +36,7 @@ foreach ($proc in $procs) {
 }
 
 # Method 2: Kill child processes (next-server, cloudflared) referencing install dir
-$allProcs = @("node.exe", "next-server.exe", "cloudflared.exe")
+$allProcs = @("node.exe", "next-server.exe", "cloudflared.exe", "ngrok.exe")
 foreach ($procName in $allProcs) {
     $procs2 = Get-WmiObject Win32_Process -Filter "Name = '$procName'" 2>$null
     foreach ($proc in $procs2) {

--- a/server.js
+++ b/server.js
@@ -29,8 +29,10 @@ server.on('upgrade', (req, socket, head) => {
     orchestratorWss.handleUpgrade(req, socket, head, ws => orchestratorWss.emit('connection', ws, req));
   } else if (pathname === '/ws/agent') {
     agentWss.handleUpgrade(req, socket, head, ws => agentWss.emit('connection', ws, req));
-  } else {
+  } else if (pathname === '/ws/ui' || pathname === '/') {
     wss.handleUpgrade(req, socket, head, ws => wss.emit('connection', ws, req));
+  } else {
+    socket.destroy();
   }
 });
 

--- a/src/headless-ls.js
+++ b/src/headless-ls.js
@@ -347,7 +347,6 @@ async function launchHeadlessLS(folderPath) {
     const args = [
         '--enable_lsp',
         '--csrf_token', csrfToken,
-        '--random_port',
         '--workspace_id', workspaceId,
         '--cloud_code_endpoint', 'https://daily-cloudcode-pa.googleapis.com',
         '--app_data_dir', 'antigravity',

--- a/start-tunnel.js
+++ b/start-tunnel.js
@@ -1,8 +1,9 @@
 // === start-tunnel.js — Production launcher for Antigravity Deck ===
 // Usage:
-//   node start-tunnel.js           → build + start + Cloudflare tunnels
+//   node start-tunnel.js           → build + start + tunnels (cloudflared or ngrok)
 //   node start-tunnel.js --local   → build + start locally (no tunnels)
 //   node start-tunnel.js --build   → force rebuild even if .next exists
+//   node start-tunnel.js --ngrok   → force ngrok even if cloudflared is available
 
 const { spawn, execSync } = require('child_process');
 const fs = require('fs');
@@ -16,6 +17,7 @@ const IS_MAC = process.platform === 'darwin';
 const IS_WIN = process.platform === 'win32';
 const LOCAL_MODE = process.argv.includes('--local');
 const FORCE_BUILD = process.argv.includes('--build');
+const FORCE_NGROK = process.argv.includes('--ngrok');
 const QUIET = process.env.QUIET === '1' || process.argv.includes('--quiet');
 
 let beUrl = null;
@@ -33,7 +35,24 @@ function findCloudflared() {
     }
     return null;
 }
-const CLOUDFLARED = findCloudflared();
+
+// Find ngrok binary — fallback tunnel provider
+function findNgrok() {
+    try { execSync('ngrok version', { stdio: 'ignore' }); return 'ngrok'; } catch { }
+    const paths = IS_WIN
+        ? [path.join(process.env.USERPROFILE || '', 'ngrok.exe'), 'C:\\ngrok\\ngrok.exe']
+        : ['/usr/local/bin/ngrok', '/opt/homebrew/bin/ngrok', '/snap/bin/ngrok'];
+    for (const p of paths) {
+        if (fs.existsSync(p)) return IS_WIN ? `"${p}"` : p;
+    }
+    return null;
+}
+
+// === Tunnel provider detection (priority: cloudflared → ngrok) ===
+const CLOUDFLARED = FORCE_NGROK ? null : findCloudflared();
+const NGROK = findNgrok();
+const TUNNEL_PROVIDER = CLOUDFLARED ? 'cloudflared' : (NGROK ? 'ngrok' : null);
+const TUNNEL_BIN = CLOUDFLARED || NGROK;
 
 function log(tag, msg) {
     if (QUIET) return;
@@ -46,11 +65,46 @@ function progress(msg) {
     if (QUIET) process.stdout.write(`\r\x1b[K  ${msg}`);
 }
 
-// Extract Cloudflare tunnel URL from process output
+// Extract tunnel URL from process output (provider-aware)
 function extractTunnelUrl(text) {
-    const stripped = text.replace(/\s+/g, '');
-    const match = stripped.match(/(https:\/\/[a-z0-9]+-[a-z0-9-]+\.trycloudflare\.com)/);
-    return match ? match[1] : null;
+    if (TUNNEL_PROVIDER === 'cloudflared') {
+        const stripped = text.replace(/\s+/g, '');
+        const match = stripped.match(/(https:\/\/[a-z0-9]+-[a-z0-9-]+\.trycloudflare\.com)/);
+        return match ? match[1] : null;
+    }
+    // ngrok URL patterns
+    const ngrokMatch = text.match(/(https:\/\/[a-z0-9-]+\.ngrok-free\.app)/);
+    if (ngrokMatch) return ngrokMatch[1];
+    const ngrokOld = text.match(/(https:\/\/[a-z0-9]+\.ngrok\.io)/);
+    if (ngrokOld) return ngrokOld[1];
+    return null;
+}
+
+// Spawn a tunnel process for the given port (provider-aware)
+function spawnTunnel(port) {
+    if (TUNNEL_PROVIDER === 'cloudflared') {
+        return spawn(TUNNEL_BIN, ['tunnel', '--url', `http://localhost:${port}`], {
+            stdio: ['ignore', 'pipe', 'pipe'], shell: true
+        });
+    }
+    // ngrok: --log stdout ensures URL appears in stdout
+    return spawn(TUNNEL_BIN, ['http', String(port), '--log', 'stdout'], {
+        stdio: ['ignore', 'pipe', 'pipe'], shell: true
+    });
+}
+
+// Check if tunnel output indicates rate limiting
+function isRateLimited(text) {
+    if (TUNNEL_PROVIDER === 'cloudflared') {
+        return text.includes('429') || text.includes('Too Many Requests') || text.includes('error code: 1015');
+    }
+    return text.includes('ERR_NGROK_') && (text.includes('rate') || text.includes('limit'));
+}
+
+// Check if ngrok authtoken is missing from output
+function isNgrokAuthMissing(text) {
+    return text.includes('ERR_NGROK_105') || text.includes('authtoken') && text.includes('invalid') ||
+           text.includes('sign up') || text.includes('ERR_NGROK_100');
 }
 
 // Start a process, track it for cleanup
@@ -113,11 +167,13 @@ function cleanup() {
     log('*', 'Shutting down...');
     for (const p of allProcs) { try { p.kill(); } catch {} }
 
-    // Kill anything still on our ports
+    // Kill tunnel provider processes
     if (IS_WIN) {
         try { execSync(`taskkill /F /FI "IMAGENAME eq cloudflared.exe"`, { stdio: 'ignore' }); } catch {}
+        try { execSync(`taskkill /F /FI "IMAGENAME eq ngrok.exe"`, { stdio: 'ignore' }); } catch {}
     } else {
         try { execSync(`pkill -f "cloudflared.*tunnel.*localhost"`, { stdio: 'ignore' }); } catch {}
+        try { execSync(`pkill -f "ngrok.*http"`, { stdio: 'ignore' }); } catch {}
     }
 
     for (const port of [BE_PORT, FE_PORT]) {
@@ -207,13 +263,17 @@ async function runLocal() {
 // TUNNEL MODE: backend → tunnel → build (with URL) → frontend → tunnel
 // ============================================================
 async function runTunnel() {
-    if (!CLOUDFLARED) {
-        console.log('\n\x1b[31m  ❌ cloudflared not found!\x1b[0m');
-        const installCmd = IS_MAC ? 'brew install cloudflared' : 'winget install cloudflare.cloudflared';
-        console.log(`  Install: ${installCmd}\n`);
+    if (!TUNNEL_PROVIDER) {
+        console.log('\n\x1b[31m  ❌ No tunnel provider found! Install one of:\x1b[0m');
+        const cfCmd = IS_MAC ? 'brew install cloudflared' : 'winget install cloudflare.cloudflared';
+        console.log(`  • cloudflared: ${cfCmd}`);
+        console.log(`  • ngrok:       https://ngrok.com/download`);
+        console.log(`\n  Then run: \x1b[1mnpm run online\x1b[0m\n`);
         process.exit(1);
     }
-    log('*', `Using cloudflared: ${CLOUDFLARED}`);
+
+    const providerName = TUNNEL_PROVIDER === 'cloudflared' ? 'Cloudflare Tunnel' : 'ngrok';
+    log('*', `Using tunnel provider: ${providerName} (${TUNNEL_BIN})`);
 
     // Kill stale processes
     killStaleProcesses([BE_PORT, FE_PORT]);
@@ -222,14 +282,28 @@ async function runTunnel() {
     const authKey = process.env.AUTH_KEY || crypto.randomBytes(16).toString('hex');
 
     if (!QUIET) {
-        console.log('\n\x1b[1m  🚀 Antigravity Deck — Starting with Cloudflare Tunnel\x1b[0m');
+        console.log(`\n\x1b[1m  🚀 Antigravity Deck — Starting with ${providerName}\x1b[0m`);
         console.log(`  🔑 Auth Key: \x1b[33m${authKey}\x1b[0m\n`);
     }
 
+    // === CLOUDFLARED PATH: dual-tunnel (BE tunnel + FE tunnel) ===
+    if (TUNNEL_PROVIDER === 'cloudflared') {
+        await _runCloudflaredTunnel(authKey);
+    }
+    // === NGROK PATH: single-tunnel (FE only — Next.js proxies /api/* to BE) ===
+    else {
+        await _runNgrokTunnel(authKey);
+    }
+
+    console.log('\n  Press Ctrl+C to stop\n');
+}
+
+// --- CLOUDFLARED: dual-tunnel mode (original behavior) ---
+async function _runCloudflaredTunnel(authKey) {
     // Step 1: Start backend
     progress('Starting backend...');
     log('*', `Starting backend on port ${BE_PORT}...`);
-    const be = startProcess('BE', 'node', ['server.js'], {
+    startProcess('BE', 'node', ['server.js'], {
         cwd: __dirname,
         env: { ...process.env, PORT: String(BE_PORT), AUTH_KEY: authKey, QUIET_POLL: '1', NODE_ENV: 'production' }
     });
@@ -238,30 +312,10 @@ async function runTunnel() {
     // Step 2: Start backend tunnel
     progress('Starting backend tunnel...');
     log('*', 'Starting Cloudflare tunnel for backend...');
-    const tunBe = spawn(CLOUDFLARED, ['tunnel', '--url', `http://localhost:${BE_PORT}`], {
-        stdio: ['ignore', 'pipe', 'pipe'], shell: true
-    });
+    const tunBe = spawnTunnel(BE_PORT);
     allProcs.push(tunBe);
 
-    beUrl = await new Promise((resolve) => {
-        const timeout = setTimeout(() => { log('*', '⚠️  Timed out waiting for backend tunnel URL'); resolve(null); }, 30000);
-        let buffer = '';
-        const handler = (data) => {
-            const text = data.toString();
-            buffer += text;
-            text.split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim()));
-            // Detect Cloudflare rate limit
-            if (buffer.includes('429') || buffer.includes('Too Many Requests') || buffer.includes('error code: 1015')) {
-                clearTimeout(timeout);
-                resolve('RATE_LIMITED');
-                return;
-            }
-            const url = extractTunnelUrl(buffer);
-            if (url) { clearTimeout(timeout); resolve(url); }
-        };
-        tunBe.stdout?.on('data', handler);
-        tunBe.stderr?.on('data', handler);
-    });
+    beUrl = await _waitForTunnelUrl(tunBe, 'TUN-BE');
 
     if (beUrl === 'RATE_LIMITED') {
         console.error('\n\x1b[33m  ⚠️  Cloudflare rate limit (429 Too Many Requests)\x1b[0m');
@@ -273,14 +327,14 @@ async function runTunnel() {
     if (!beUrl) { log('*', '❌ Failed to get backend tunnel URL'); process.exit(1); }
     log('*', `✅ Backend tunnel: ${beUrl}`);
 
-    // Step 3: Build frontend (always — needs NEXT_PUBLIC_BACKEND_URL baked in)
+    // Step 3: Build frontend (needs NEXT_PUBLIC_BACKEND_URL baked in)
     buildFrontend({ NEXT_PUBLIC_BACKEND_URL: beUrl, NEXT_PUBLIC_BACKEND_PORT: String(BE_PORT) });
     try { fs.writeFileSync(path.join(__dirname, 'frontend', '.next', '.backend-port'), String(BE_PORT)); } catch { }
 
     // Step 4: Start frontend
     progress('Starting frontend...');
     log('*', `Starting frontend on port ${FE_PORT}...`);
-    const fe = startProcess('FE', 'npx', ['next', 'start', '--port', String(FE_PORT)], {
+    startProcess('FE', 'npx', ['next', 'start', '--port', String(FE_PORT)], {
         cwd: path.join(__dirname, 'frontend'),
         env: { ...process.env, NEXT_PUBLIC_BACKEND_URL: beUrl, BACKEND_PORT: String(BE_PORT), NODE_ENV: 'production' }
     });
@@ -289,43 +343,122 @@ async function runTunnel() {
     // Step 5: Start frontend tunnel
     progress('Starting frontend tunnel...');
     log('*', 'Starting Cloudflare tunnel for frontend...');
-    const tunFe = spawn(CLOUDFLARED, ['tunnel', '--url', `http://localhost:${FE_PORT}`], {
-        stdio: ['ignore', 'pipe', 'pipe'], shell: true
-    });
+    const tunFe = spawnTunnel(FE_PORT);
     allProcs.push(tunFe);
 
-    feUrl = await new Promise((resolve) => {
-        const timeout = setTimeout(() => { log('*', '⚠️  Timed out waiting for frontend tunnel URL'); resolve(null); }, 30000);
+    feUrl = await _waitForTunnelUrl(tunFe, 'TUN-FE');
+
+    if (feUrl === 'RATE_LIMITED') {
+        console.error('\n\x1b[33m  ⚠️  Cloudflare rate limit on frontend tunnel\x1b[0m');
+        console.error('  Backend tunnel is working. Wait 5-10 min and try again.\n');
+        feUrl = null;
+    }
+
+    _printResults(authKey, tunBe, tunFe);
+}
+
+// --- NGROK: single-tunnel mode (tunnel FE only, Next.js proxies /api/*) ---
+async function _runNgrokTunnel(authKey) {
+    // Step 1: Start backend (localhost only — no tunnel needed)
+    progress('Starting backend...');
+    log('*', `Starting backend on port ${BE_PORT}...`);
+    startProcess('BE', 'node', ['server.js'], {
+        cwd: __dirname,
+        env: { ...process.env, PORT: String(BE_PORT), AUTH_KEY: authKey, ALLOW_LOCALHOST_BYPASS: 'true', QUIET_POLL: '1', NODE_ENV: 'production' }
+    });
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // Step 2: Build frontend (NO NEXT_PUBLIC_BACKEND_URL — uses relative /api/* proxy)
+    const nextDir = path.join(__dirname, 'frontend', '.next');
+    const portFile = path.join(nextDir, '.backend-port');
+    let needBuild = FORCE_BUILD || !fs.existsSync(nextDir);
+    if (!needBuild) {
+        try {
+            const builtPort = fs.readFileSync(portFile, 'utf8').trim();
+            if (builtPort !== String(BE_PORT)) needBuild = true;
+        } catch { needBuild = true; }
+    }
+    if (needBuild) {
+        buildFrontend({ BACKEND_PORT: String(BE_PORT) });
+        try { fs.writeFileSync(portFile, String(BE_PORT)); } catch { }
+    } else {
+        log('*', '✅ Frontend already built (use --build to force rebuild)');
+    }
+
+    // Step 3: Start frontend
+    progress('Starting frontend...');
+    log('*', `Starting frontend on port ${FE_PORT}...`);
+    startProcess('FE', 'npx', ['next', 'start', '--port', String(FE_PORT)], {
+        cwd: path.join(__dirname, 'frontend'),
+        env: { ...process.env, BACKEND_PORT: String(BE_PORT), NODE_ENV: 'production' }
+    });
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // Step 4: Single tunnel pointing to frontend
+    progress('Starting ngrok tunnel...');
+    log('*', `Starting ngrok tunnel for frontend (port ${FE_PORT})...`);
+    const tunFe = spawnTunnel(FE_PORT);
+    allProcs.push(tunFe);
+
+    feUrl = await _waitForTunnelUrl(tunFe, 'TUN-FE');
+    beUrl = feUrl; // Same URL — all API calls go through FE proxy
+
+    if (feUrl === 'RATE_LIMITED') {
+        console.error('\n\x1b[33m  ⚠️  ngrok rate limit\x1b[0m');
+        console.error('  Please wait and try again, or use local mode: \x1b[1mnode start-tunnel.js --local\x1b[0m\n');
+        process.exit(1);
+    }
+    if (feUrl === 'AUTH_MISSING') {
+        console.error('\n\x1b[31m  ❌ ngrok authtoken not configured!\x1b[0m');
+        console.error('  Sign up for free at: \x1b[36mhttps://dashboard.ngrok.com/signup\x1b[0m');
+        console.error('  Then run: \x1b[1mngrok config add-authtoken YOUR_TOKEN\x1b[0m\n');
+        process.exit(1);
+    }
+    if (!feUrl) { log('*', '❌ Failed to get ngrok tunnel URL'); process.exit(1); }
+
+    _printResults(authKey, null, tunFe);
+}
+
+// --- Wait for tunnel URL from process output ---
+async function _waitForTunnelUrl(tunnelProc, logTag) {
+    return new Promise((resolve) => {
+        const timeout = setTimeout(() => { log('*', `⚠️  Timed out waiting for ${logTag} tunnel URL`); resolve(null); }, 30000);
         let buffer = '';
         const handler = (data) => {
             const text = data.toString();
             buffer += text;
-            text.split('\n').filter(l => l.trim()).forEach(l => log('TUN-FE', l.trim()));
-            // Detect Cloudflare rate limit
-            if (buffer.includes('429') || buffer.includes('Too Many Requests') || buffer.includes('error code: 1015')) {
+            text.split('\n').filter(l => l.trim()).forEach(l => log(logTag, l.trim()));
+            if (isRateLimited(buffer)) {
                 clearTimeout(timeout);
-                console.error('\n\x1b[33m  ⚠️  Cloudflare rate limit on frontend tunnel (429)\x1b[0m');
-                console.error('  Backend tunnel is working. Wait 5-10 min and try again.\n');
-                resolve(null);
+                resolve('RATE_LIMITED');
+                return;
+            }
+            if (TUNNEL_PROVIDER === 'ngrok' && isNgrokAuthMissing(buffer)) {
+                clearTimeout(timeout);
+                resolve('AUTH_MISSING');
                 return;
             }
             const url = extractTunnelUrl(buffer);
             if (url) { clearTimeout(timeout); resolve(url); }
         };
-        tunFe.stdout?.on('data', handler);
-        tunFe.stderr?.on('data', handler);
+        tunnelProc.stdout?.on('data', handler);
+        tunnelProc.stderr?.on('data', handler);
     });
+}
 
+// --- Print results and QR code ---
+function _printResults(authKey, tunBe, tunFe) {
     const qrUrl = feUrl ? `${feUrl}?key=${authKey}` : null;
     if (QUIET) process.stdout.write('\r\x1b[K');
 
     if (feUrl) {
+        const providerLabel = TUNNEL_PROVIDER === 'cloudflared' ? 'Cloudflare' : 'ngrok';
         console.log('\n' + '='.repeat(60));
-        console.log('\x1b[1m\x1b[32m  🌐 READY! Open this URL on any device:\x1b[0m');
+        console.log(`\x1b[1m\x1b[32m  🌐 READY! (${providerLabel}) Open this URL on any device:\x1b[0m`);
         console.log(`\x1b[1m  👉 ${feUrl}\x1b[0m`);
         console.log(`  🔑 Key: \x1b[33m${authKey}\x1b[0m`);
         console.log('='.repeat(60));
-        console.log(`  Backend API: ${beUrl}`);
+        if (beUrl && beUrl !== feUrl) console.log(`  Backend API: ${beUrl}`);
         console.log(`  Local:       http://localhost:${FE_PORT}`);
         console.log('='.repeat(60));
 
@@ -350,6 +483,7 @@ async function runTunnel() {
     // Write tunnel info file
     const infoFile = path.join(__dirname, '.tunnel-info.txt');
     const info = [
+        `Provider: ${TUNNEL_PROVIDER}`,
         `Frontend: ${feUrl || 'FAILED'}`,
         `Backend:  ${beUrl || 'FAILED'}`,
         `Auth Key: ${authKey}`,
@@ -363,13 +497,15 @@ async function runTunnel() {
 
     // Keep remaining output flowing
     if (!QUIET) {
-        tunBe.stdout?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim())));
-        tunBe.stderr?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim())));
-        tunFe.stdout?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-FE', l.trim())));
-        tunFe.stderr?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-FE', l.trim())));
+        if (tunBe) {
+            tunBe.stdout?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim())));
+            tunBe.stderr?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-BE', l.trim())));
+        }
+        if (tunFe) {
+            tunFe.stdout?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-FE', l.trim())));
+            tunFe.stderr?.on('data', d => d.toString().split('\n').filter(l => l.trim()).forEach(l => log('TUN-FE', l.trim())));
+        }
     }
-
-    console.log('\n  Press Ctrl+C to stop\n');
 }
 
 // === Entry point ===


### PR DESCRIPTION
# Ngrok Remote Access — Complete Guide

> **Purpose**: Access Antigravity Deck from any device (phone, tablet, another laptop) over the internet using ngrok as a secure tunnel provider.

---

## Table of Contents

1. [Overview](#overview)
2. [Architecture](#architecture)
3. [Prerequisites](#prerequisites)
4. [Quick Start](#quick-start)
5. [How It Works — Deep Dive](#how-it-works--deep-dive)
6. [Configuration Reference](#configuration-reference)
7. [Mobile-Specific Behavior](#mobile-specific-behavior)
8. [Troubleshooting](#troubleshooting)
9. [Security Model](#security-model)
10. [Provider Comparison: Cloudflared vs Ngrok](#provider-comparison-cloudflared-vs-ngrok)
11. [Files Modified](#files-modified)
12. [Known Limitations](#known-limitations)

---

## Overview

Antigravity Deck supports two tunnel providers for remote access:

| Provider      | Priority | Account Required | Tunnels Used | Best For                    |
|---------------|----------|------------------|--------------|-----------------------------|
| **cloudflared** | 1st (default) | No (anonymous)  | 2 (BE + FE)  | Zero-setup, dual-tunnel     |
| **ngrok**       | 2nd (fallback) | Yes (free tier) | 1 (FE only)  | When cloudflared unavailable |

The system auto-detects which provider is installed. If both are present, cloudflared is preferred unless `--ngrok` is passed.

### Why ngrok as a fallback?

Cloudflare's Quick Tunnels are anonymous and ephemeral but can hit aggressive rate limits (HTTP 429 / error 1015) after repeated restarts. When this happens, ngrok provides immediate, reliable fallback access with a free-tier account.

---

## Architecture

### Cloudflared Mode (Dual Tunnel)

```
┌─────────────────────────────────────────────────────────────────┐
│                      Your Machine (localhost)                    │
│                                                                 │
│  ┌──────────┐       ┌──────────┐                               │
│  │ Backend  │:9807  │ Frontend │:9808                           │
│  │ Express  │◄──────│ Next.js  │                               │
│  │ server.js│       │          │                               │
│  └────┬─────┘       └─────┬────┘                               │
│       │                   │                                     │
└───────┼───────────────────┼─────────────────────────────────────┘
        │                   │
   ┌────┴────┐         ┌────┴────┐
   │Cloudflare│        │Cloudflare│
   │Tunnel BE │        │Tunnel FE │
   └────┬────┘         └────┬────┘
        │                   │
   https://xxx-yyy       https://aaa-bbb
   .trycloudflare.com   .trycloudflare.com
                   ▲
                   │
              📱 Mobile
```

**Flow**: Two independent tunnels. Frontend build bakes the backend tunnel URL into `NEXT_PUBLIC_BACKEND_URL` at compile time. WebSocket connects directly to backend tunnel.

### Ngrok Mode (Single Tunnel) ← New

```
┌──────────────────────────────────────────────────────────────────┐
│                      Your Machine (localhost)                     │
│                                                                  │
│  ┌──────────┐  localhost:9807  ┌──────────────┐                 │
│  │ Backend  │◄────────────────│   Frontend    │:9808            │
│  │ Express  │  (Next.js proxy  │   Next.js     │                │
│  │ server.js│   /api/* → BE)   │ next.config.ts│                │
│  │          │  (/ws/* → BE)    │               │                │
│  └──────────┘                  └───────┬───────┘                │
│                                        │                         │
└────────────────────────────────────────┼─────────────────────────┘
                                         │
                                    ┌────┴────┐
                                    │  ngrok  │
                                    │ Tunnel  │
                                    └────┬────┘
                                         │
                                 https://xxxx-yy-zz
                                 .ngrok-free.app
                                         ▲
                                         │
                                    📱 Mobile
```

**Flow**: Single tunnel to frontend port 9808. Next.js reverse-proxy forwards:
- `/api/*` → `http://localhost:9807/api/*` (HTTP REST)
- `/ws/*` → `http://localhost:9807/ws/*` (WebSocket upgrade)

The backend never needs its own tunnel. It sets `ALLOW_LOCALHOST_BYPASS=true` to accept unauthenticated requests from the Next.js proxy on localhost.

---

## Prerequisites

### 1. Install ngrok

**Windows (winget):**
```powershell
winget install ngrok.ngrok
```

**Windows (manual):**
1. Download from https://ngrok.com/download
2. Extract `ngrok.exe` to your PATH or user profile

**macOS:**
```bash
brew install ngrok
```

**Linux:**
```bash
sudo snap install ngrok   # or download from ngrok.com
```

### 2. Create a Free Account & Configure Auth Token

1. Sign up at https://dashboard.ngrok.com/signup (free)
2. Copy your authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
3. Run:

```bash
ngrok config add-authtoken YOUR_TOKEN_HERE
```

This is a **one-time setup** — the token persists in ngrok's config file.

### 3. Verify Installation

```bash
ngrok version
# ngrok version 3.x.x
```

---

## Quick Start

### Option A: Auto-detect (recommended)

```bash
npm run online
```

This detects available providers in order: cloudflared → ngrok → error.

### Option B: Force ngrok

```bash
npm run online:ngrok
```

Forces ngrok even if cloudflared is installed.

### What Happens

1. Backend starts on `localhost:9807`
2. Frontend builds (if needed) and starts on `localhost:9808`
3. Ngrok tunnel opens to port 9808
4. Terminal displays:
   - 🌐 Public URL (e.g., `https://xxxx-yy-zz.ngrok-free.app`)
   - 🔑 Auth Key (32-char hex string)
   - 📱 QR code (auto-login URL with key embedded)
5. Tunnel info written to `.tunnel-info.txt`

### Connect from Mobile

**Method 1 — QR Code (fastest):**
Scan the QR code displayed in your terminal. The URL includes the auth key so you're logged in automatically.

**Method 2 — Manual URL:**
1. Open the ngrok URL in your mobile browser
2. On first visit, ngrok shows a "Visit Site" interstitial — tap through
3. Enter the auth key when prompted (or append `?key=YOUR_KEY` to the URL)

### Stop

Press `Ctrl+C` in the terminal. All processes (backend, frontend, ngrok) are cleaned up automatically.

---

## How It Works — Deep Dive

### Startup Sequence (`start-tunnel.js`)

```
1. Kill stale processes on ports 9807, 9808
2. Generate random AUTH_KEY (or use AUTH_KEY env var)
3. Start backend:
     node server.js
     env: PORT=9807, AUTH_KEY=<key>, ALLOW_LOCALHOST_BYPASS=true, NODE_ENV=production
4. Wait 3 seconds for backend to initialize
5. Check if frontend build is needed:
     - Missing .next directory? → rebuild
     - .next/.backend-port doesn't match 9807? → rebuild
     - --build flag? → rebuild
6. Build frontend (if needed):
     npx next build
     env: BACKEND_PORT=9807
7. Start frontend:
     npx next start --port 9808
     env: BACKEND_PORT=9807, NODE_ENV=production
8. Wait 3 seconds for frontend to initialize
9. Start ngrok tunnel:
     ngrok http 9808 --log stdout
10. Parse tunnel URL from ngrok stdout
11. Display URL, QR code, write .tunnel-info.txt
12. Keep running until Ctrl+C
```

### Next.js Reverse Proxy (`frontend/next.config.ts`)

The frontend's `rewrites()` configuration is the linchpin of single-tunnel mode:

```typescript
async rewrites() {
    return [
      {
        source: '/api/:path*',
        destination: `http://localhost:${BE_PORT}/api/:path*`,
      },
      {
        source: '/ws/:path*',
        destination: `http://localhost:${BE_PORT}/ws/:path*`,
      },
    ];
  },
```

- **`/api/*`**: All REST API calls from the browser → Next.js → backend. This includes conversation CRUD, workspace management, step fetching, cascade control, etc.
- **`/ws/*`**: WebSocket upgrade requests from the browser → Next.js → backend. This enables real-time streaming of AI responses, status updates, and live workspace monitoring.

### WebSocket Routing (`server.js`)

The backend Express server handles WebSocket upgrades on four explicit paths:

```javascript
server.on('upgrade', (req, socket, head) => {
  const { pathname } = new URL(req.url, 'http://localhost');
  if (pathname === '/ws/orchestrator') { /* orchestrator WS */ }
  else if (pathname === '/ws/agent')   { /* agent WS */ }
  else if (pathname === '/ws/ui' || pathname === '/') { /* UI WS */ }
  else { socket.destroy(); }
});
```

The frontend `ws-service.ts` connects to `/ws/ui` which Next.js proxies to the backend.

### Auth Flow (`frontend/lib/auth.ts`)

```
1. User opens ngrok URL with ?key=<auth_key>
2. Frontend extracts key from URL query parameter
3. Key stored in BOTH:
   - localStorage ('antigravity_auth_key')
   - Cookie ('ag_auth_key', 30-day expiry, SameSite=Strict)
4. All API requests include X-Auth-Key header
5. WebSocket URL includes ?auth_key=<key> query param
```

**Why dual storage?** Mobile browsers (especially iOS Safari) can purge localStorage when killing background tabs under memory pressure. Cookies survive this, so the auth key is always recoverable.

### Localhost Bypass (`ALLOW_LOCALHOST_BYPASS`)

When ngrok mode is active, the backend environment includes `ALLOW_LOCALHOST_BYPASS=true`. This tells the backend auth middleware:

> "If the request comes from 127.0.0.1 / localhost, skip auth key validation."

This is necessary because Next.js proxy requests appear to originate from localhost, but they don't carry the `X-Auth-Key` header (that's a browser-to-Next.js concern, not a Next.js-to-backend concern). Without this bypass, every proxied API call would return 401 Unauthorized.

### WebSocket URL Resolution (`frontend/lib/config.ts`)

The frontend resolves the WebSocket URL at runtime (not build time):

```typescript
async function _resolveWsUrl(): Promise<string> {
    const isLocal = hostname === 'localhost' || ...;

    // Always try /api/ws-url first
    const { wsPort } = await fetch('/api/ws-url').then(r => r.json());

    if (isLocal) {
        return `ws://${hostname}:${wsPort}`;  // Direct to backend
    }

    // Remote: try same host (works if WS upgrade is supported)
    return `${protocol}://${window.location.host}`;
}
```

For ngrok mode, the WS URL resolves to `wss://xxxx.ngrok-free.app`, and the `ws-service.ts` appends `/ws/ui` to get `wss://xxxx.ngrok-free.app/ws/ui`. This is proxied by Next.js rewrites to `http://localhost:9807/ws/ui`.

### State Persistence for Mobile Resume

Mobile browsers aggressively kill background tabs. When the user returns to the app:

1. **Cached detected state**: `localStorage('antigravity-cached-detected')` — prevents flash of "Launch Antigravity" onboarding screen
2. **Cached steps**: Last 30 conversation steps cached in localStorage — instant content display before WS reconnects
3. **Cached WS URL**: `localStorage('antigravity-ws-url')` — no HTTP round-trip needed on cold reload
4. **Grace period**: 5-second reconnect grace suppresses disconnect indicators after mount

### Headless Language Server (`src/headless-ls.js`)

When connecting remotely, the user can't launch the Antigravity IDE GUI. Instead, the backend spawns a **headless Language Server** process:

```
1. Detect LS binary from running IDE process or known install paths
2. Get extension server auth (port + CSRF) from running IDE
3. Create mock parent pipe (Windows named pipe / Unix socket)
4. Spawn LS with args:
     --enable_lsp
     --csrf_token <random>
     --workspace_id <encoded_path>
     --parent_pipe_path <pipe>
     --extension_server_port <port>
     --extension_server_csrf_token <token>
5. Wait for LS to bind HTTP/HTTPS ports
6. Call AddTrackedWorkspace API to bind workspace folder
7. Register in lsInstances array
8. Frontend sees new workspace via conversations_updated broadcast
```

**Important**: The headless LS requires at least one Antigravity IDE window to be open on the host machine (for extension server auth). It cannot run standalone.

---

## Configuration Reference

### Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `AUTH_KEY` | Random 32-hex | Override the generated auth key |
| `ALLOW_LOCALHOST_BYPASS` | `false` | Skip auth for localhost requests (set automatically in ngrok mode) |
| `BACKEND_PORT` | `9807` (prod) / `3500` (dev) | Backend port |
| `QUIET_POLL` | `0` | Suppress LS polling logs |
| `NODE_ENV` | — | Set to `production` by tunnel launcher |

### CLI Flags (`start-tunnel.js`)

| Flag | Description |
|------|-------------|
| `--ngrok` | Force ngrok even if cloudflared is available |
| `--local` | No tunnels — local-only mode |
| `--build` | Force frontend rebuild (even if `.next` exists) |
| `--quiet` | Minimal output |

### NPM Scripts

| Script | Command | Description |
|--------|---------|-------------|
| `npm run online` | `node start-tunnel.js` | Auto-detect provider (cloudflared → ngrok) |
| `npm run online:ngrok` | `node start-tunnel.js --ngrok` | Force ngrok |
| `npm run prod` | `node start-tunnel.js --local` | Local production (no tunnel) |
| `npm run dev` | `concurrently BE FE` | Development mode (ports 3500/3000) |

### Ports

| Port | Service | Notes |
|------|---------|-------|
| `9807` | Backend (Express) | Production only — dev uses 3500 |
| `9808` | Frontend (Next.js) | Production only — dev uses 3000 |
| `3500` | Backend (dev) | Used during `npm run dev` |
| `3000` | Frontend (dev) | Used during `npm run dev` |

### Output Files

| File | Description |
|------|-------------|
| `.tunnel-info.txt` | Active tunnel URL, auth key, timestamps |
| `frontend/.next/.backend-port` | Port marker to detect stale builds |

---

## Mobile-Specific Behavior

### Sidebar Auto-Close

On mobile devices (screen width < 768px), the sidebar drawer auto-closes when the user:
- Selects a workspace
- Opens a conversation
- Clicks a navigation item (Settings, Agent Hub, etc.)
- Creates a new workspace

This is handled by the `closeMobile()` helper in `app-sidebar.tsx`:

```typescript
const closeMobile = useCallback(() => {
    if (isMobile) setOpenMobile(false)
}, [isMobile, setOpenMobile])
```

### Page Lifecycle Events

The WebSocket service handles mobile browser lifecycle events:

- **`visibilitychange` → hidden**: Records timestamp
- **`visibilitychange` → visible**: If hidden > 5s, force-reconnects (assumes WS is stale)
- **`freeze`** (iOS/mobile): Clean-closes WS to avoid stuck CLOSING state
- **`resume`**: Immediately reconnects

### PWA Considerations

The app includes a service worker and PWA manifest. On mobile:
- Add to Home Screen for native-app feel
- Push notifications work via VAPID keys
- Offline state shows cached content gracefully

---

## Troubleshooting

### "LS Connected" green but chatbox empty

**Cause**: WebSocket connection failed — the AI response stream can't reach the browser.

**Fix**: Ensure `next.config.ts` has the `/ws/*` rewrite rule and the build includes it. Force rebuild:
```bash
npm run online:ngrok -- --build
```

### "WS" indicator shows red

**Cause**: WebSocket upgrade rejected by ngrok or Next.js.

**Check**:
1. `frontend/next.config.ts` must have both `/api/*` and `/ws/*` rewrites
2. `server.js` must accept `/ws/ui` path in upgrade handler
3. Rebuild frontend after config changes

### Workspace shows orange HL badge

**Cause**: Successfully launched a headless Language Server. Orange = headless (vs blue = IDE).

This is normal and expected when connecting remotely.

### "Headless LS failed to bind ports within timeout"

**Cause**: The Language Server binary crashed on startup — usually a bad flag.

**Check**:
- `src/headless-ls.js` should NOT pass `--random_port` (removed — was a deprecated flag)
- At least one Antigravity IDE window must be open (provides extension server auth)
- Verify the LS binary exists at the detected path

### ngrok shows "ERR_NGROK_105" or "authtoken invalid"

**Fix**: Configure your authtoken:
```bash
ngrok config add-authtoken YOUR_TOKEN
```

### Process crashes with "exit code: 1" on restart

**Cause**: Port contention from previous run's zombie processes.

**Fix**: The launcher automatically kills stale processes on ports 9807/9808 at startup. If it still fails:
```powershell
# Windows
taskkill /F /FI "IMAGENAME eq node.exe"
taskkill /F /FI "IMAGENAME eq ngrok.exe"

# macOS/Linux
lsof -ti :9807 :9808 | xargs kill -9
pkill -f "ngrok.*http"
```

### Cloudflare rate limited (429)

Switch to ngrok:
```bash
npm run online:ngrok
```

Or wait 5-10 minutes and retry `npm run online`.

### Mobile shows "Launch Antigravity" loop

**Cause**: The `detected` state is false because neither WebSocket nor HTTP polling confirmed an LS instance.

**Check**:
1. Backend is running and healthy: `curl http://localhost:9807/api/status`
2. At least one workspace is open in the IDE on the host machine
3. The `detected` state is NOT reset on WS close (check `websocket.ts` line 157)

---

## Security Model

### Authentication

- **Auth Key**: 32-character random hex generated per session
- **Transport**: HTTPS (ngrok provides TLS termination)
- **Header**: `X-Auth-Key` on all HTTP requests
- **WebSocket**: `?auth_key=<key>` query parameter
- **Storage**: localStorage + cookie (dual redundancy for mobile)
- **Cookie**: `SameSite=Strict`, 30-day expiry

### Localhost Bypass

When `ALLOW_LOCALHOST_BYPASS=true`, requests from `127.0.0.1` skip auth validation. This is ONLY set in ngrok mode where Next.js proxies requests from the browser through localhost.

### Network Exposure

- Backend port 9807 is **never exposed** to the internet in ngrok mode
- Only port 9808 (frontend) is tunneled
- All backend communication goes through the Next.js reverse proxy on localhost
- Ngrok provides TLS encryption for the public-facing connection

### Helmet.js Headers

The Express backend applies security headers via Helmet:
- Content Security Policy (CSP)
- HSTS (1 year, includeSubDomains, preload)
- X-Frame-Options: DENY
- X-Content-Type-Options: nosniff
- Referrer-Policy: strict-origin-when-cross-origin

### Rate Limiting

Express applies `express-rate-limit` to prevent brute-force auth key guessing.

---

## Provider Comparison: Cloudflared vs Ngrok

| Aspect | Cloudflared | Ngrok |
|--------|------------|-------|
| **Account** | None (anonymous) | Free account required |
| **Setup** | `winget install cloudflare.cloudflared` | `winget install ngrok.ngrok` + authtoken |
| **Tunnels** | 2 (BE + FE) | 1 (FE only) |
| **Build** | Required per session (bakes BE URL) | Cached (no URL baking needed) |
| **Startup Time** | ~30-60s (includes rebuild) | ~15-30s (reuses cached build) |
| **URL Format** | `https://xxx-yyy.trycloudflare.com` | `https://xxxx.ngrok-free.app` |
| **URL Stability** | New URL every restart | New URL every restart (free tier) |
| **Rate Limits** | Aggressive (429 after ~10 restarts) | Generous (free: 1 tunnel, 20 conn/min) |
| **WebSocket** | Direct to backend tunnel | Via Next.js proxy |
| **Interstitial** | None | "Visit Site" page on first visit |
| **CLI** | `cloudflared tunnel --url ...` | `ngrok http PORT --log stdout` |

### When to Use Each

- **cloudflared**: First choice. No account, no interstitial page. Just works.
- **ngrok**: When cloudflared is rate-limited or unavailable. Requires one-time account setup.

---

## Files Modified

### Core Changes for Ngrok Support

| File | What Changed |
|------|-------------|
| [`start-tunnel.js`](../start-tunnel.js) | Added `findNgrok()`, provider abstraction, `_runNgrokTunnel()`, `ALLOW_LOCALHOST_BYPASS` env, ngrok URL extraction, ngrok rate-limit/auth detection |
| [`server.js`](../server.js) | Added `/ws/ui` path to WebSocket upgrade handler |
| [`frontend/next.config.ts`](../frontend/next.config.ts) | Added `/ws/:path*` rewrite rule for WebSocket proxying |
| [`frontend/lib/ws-service.ts`](../frontend/lib/ws-service.ts) | Changed WS connection to use explicit `/ws/ui` path |
| [`frontend/lib/config.ts`](../frontend/lib/config.ts) | Updated `getWsUrl()` to resolve via `/api/ws-url` first; localStorage caching |
| [`frontend/lib/websocket.ts`](../frontend/lib/websocket.ts) | Prevented `detected` state reset on WS close; added cached state restore |
| [`frontend/lib/auth.ts`](../frontend/lib/auth.ts) | Dual localStorage + cookie storage for auth key resilience |
| [`frontend/components/app-sidebar.tsx`](../frontend/components/app-sidebar.tsx) | Added `closeMobile()` for auto-close on navigation |
| [`src/headless-ls.js`](../src/headless-ls.js) | Removed deprecated `--random_port` flag |
| [`package.json`](../package.json) | Added `online:ngrok` script |
| [`scripts/setup.ps1`](../scripts/setup.ps1) | Added ngrok detection in dependency check |
| [`scripts/setup.sh`](../scripts/setup.sh) | Added ngrok detection in dependency check |
| [`scripts/uninstall.ps1`](../scripts/uninstall.ps1) | Added `ngrok.exe` to cleanup kill list |

---

## Known Limitations

1. **Free-tier URL changes**: ngrok free tier generates a new URL on every restart. Consider ngrok paid plans for stable custom domains.

2. **Interstitial page**: ngrok free tier shows a "Visit Site" interstitial on first visit per session. Users must tap through it.

3. **One tunnel limit**: ngrok free tier allows only one tunnel at a time. The single-tunnel architecture (FE only) works within this constraint.

4. **Auth key per session**: The auth key is regenerated on each `npm run online:ngrok` restart. Set `AUTH_KEY` environment variable for persistence:
   ```bash
   AUTH_KEY=my_fixed_key_here npm run online:ngrok
   ```

5. **Headless LS requires IDE**: The headless Language Server cannot authorize without at least one Antigravity IDE window running on the host machine.

6. **WebSocket via proxy**: In ngrok mode, WebSocket connections go through Next.js's reverse proxy, adding marginal latency compared to cloudflared's direct backend tunnel. This is unnoticeable in practice.
