### PR TITLE
docs: lead README with 'Remote control for Antigravity' (SEO/discoverability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 🔮 Antigravity Deck
 
-Full-featured web dashboard for [Antigravity](https://antigravity.google). View, send, and manage AI conversations from any device — with a searchable all-time history across every project, live cascade control, resource monitoring, source control, IDE tools, and secure remote access.
+**Remote control for [Antigravity](https://antigravity.google) — manage AI conversations, cascades, and workspaces from any device.**
+
+Full-featured web dashboard for Antigravity. View, send, and manage AI conversations from any device — with a searchable all-time history across every project, live cascade control, resource monitoring, source control, IDE tools, and secure remote access.
 
 > Built for **Antigravity 2.0.11+**, which runs a single shared **hub** Language Server. The Deck auto-detects the hub, tracks your workspaces on it, and streams full conversation history out of the IDE's Jetbox subsystem.
 


### PR DESCRIPTION
Pairs with the new repo **Topics** to make the repo surface for Google queries like `antigravity remote` / `antigravity remote control`.

## What
- Add a bold tagline directly under the README H1: **"Remote control for Antigravity — manage AI conversations, cascades, and workspaces from any device."**
- This puts the target keyword phrase in the highest-weighted on-page zone (first text after H1), which previously only said "Full-featured web dashboard…" with "remote" buried at the end of the paragraph.

## Why
- GitHub auto-generates the page `<title>`/`<meta description>` from repo name + description (already good), but the README H1/intro is the main on-page content Google scores. "remote control" was absent there.
- Must land on `main` (default branch) to affect the rendered repo page.

## Test plan
- [ ] Confirm README renders with the tagline on the repo page after merge
- [ ] (Optional, days later) Re-check Google ranking for `antigravity remote control`