### PR TITLE
fix: resolve conversation history loading issue due to LS API startIn…

### DIFF
--- a/src/poller.js
+++ b/src/poller.js
@@ -268,7 +268,7 @@ async function pollConversation(activeConvId, info) {
 
         // Use Antigravity LS API workaround (JSON may ignore startIndex)
         const expectedRange = fetchTo - fetchFrom;
-        const apiStartedAt = detectApiStartIndex(freshSteps.length, expectedRange, fetchFrom);
+        const apiStartedAt = detectApiStartIndex(freshSteps, expectedRange, fetchFrom);
 
         // Process the fresh steps — map each to the correct cache index
         let updatedCount = 0;

--- a/src/step-cache.js
+++ b/src/step-cache.js
@@ -44,21 +44,35 @@ async function fetchAllSteps(convId, totalSteps, inst = null, fromIndex = 0) {
     const jsonSteps = jsonData.steps || [];
     const jsonCount = jsonSteps.length;
 
-    // Check if JSON returned enough (respects fromIndex or returned from 0)
     const expectedCount = maxSteps - fromIndex;
-    if (jsonCount >= expectedCount) {
-        return { steps: jsonSteps.slice(0, expectedCount), hasGaps: false };
+    const jsonActualStart = detectApiStartIndex(jsonSteps, expectedCount, fromIndex);
+    const jsonActualEnd = jsonActualStart + jsonCount;
+    const desiredEnd = maxSteps;
+
+    // If JSON response fully covers the desired range, slice and return
+    if (jsonActualStart <= fromIndex && jsonActualEnd >= desiredEnd) {
+        const sliceStart = fromIndex - jsonActualStart;
+        const sliceEnd = desiredEnd - jsonActualStart;
+        return { steps: jsonSteps.slice(sliceStart, sliceEnd), hasGaps: false };
     }
 
     // Step 2: Binary protobuf for remaining steps
     const { callApiBinary } = require('./api');
-    console.log(`[*] JSON returned ${jsonCount}/${expectedCount} steps (from ${fromIndex}). Using binary protobuf for remaining...`);
+    console.log(`[*] JSON returned ${jsonCount} steps (actual range: [${jsonActualStart}-${jsonActualEnd}]). Expected range: [${fromIndex}-${desiredEnd}]. Using binary protobuf for remaining...`);
 
-    const allSteps = [...jsonSteps];
+    const allSteps = [];
+
+    // Extract overlapping part from JSON steps
+    if (jsonActualEnd > fromIndex) {
+        const jsonSliceStart = Math.max(0, fromIndex - jsonActualStart);
+        const jsonSliceEnd = Math.min(jsonCount, desiredEnd - jsonActualStart);
+        if (jsonSliceStart < jsonSliceEnd) {
+            allSteps.push(...jsonSteps.slice(jsonSliceStart, jsonSliceEnd));
+        }
+    }
+
     let hasGaps = false;
-    // Detect if JSON API ignored our fromIndex and returned from 0
-    const jsonActualStart = jsonCount > expectedCount ? 0 : fromIndex;
-    let binaryStart = jsonActualStart + jsonCount;
+    let binaryStart = fromIndex + allSteps.length;
     let consecutiveEmptyRanges = 0;
     const MAX_EMPTY_RANGES = 5;
     const SUB_BATCH_SIZE = 50;
@@ -173,11 +187,45 @@ async function ensureCached(convId, inst = null) {
     }
 }
 
+// --- Helper: Extract actual step index from a step object ---
+function getStepIndex(step) {
+    if (!step) return undefined;
+    if (step.metadata) {
+        if (typeof step.metadata.stepIndex === 'number') return step.metadata.stepIndex;
+        if (typeof step.metadata.step_index === 'number') return step.metadata.step_index;
+    }
+    if (typeof step.stepIndex === 'number') return step.stepIndex;
+    if (typeof step.step_index === 'number') return step.step_index;
+    return undefined;
+}
+
 // --- Shared helper: Antigravity LS API startIndex workaround ---
 // Antigravity LS JSON API may ignore startIndex and return from 0 (both macOS & Windows).
 // Detect: if we got more steps than the range we requested, API started at 0.
-function detectApiStartIndex(stepsLength, expectedRange, requestedFrom) {
-    return stepsLength > expectedRange ? 0 : requestedFrom;
+function detectApiStartIndex(steps, expectedRange, requestedFrom) {
+    if (!steps || steps.length === 0) return requestedFrom;
+
+    // Support backward compatibility if length (number) is passed instead of array
+    if (typeof steps === 'number') {
+        return steps > expectedRange ? 0 : requestedFrom;
+    }
+
+    const firstIdx = getStepIndex(steps[0]);
+    if (firstIdx !== undefined) {
+        return firstIdx;
+    }
+
+    // Fallback: If requestedFrom > 0 but first step is obviously the beginning of conversation
+    const firstType = steps[0].type || '';
+    if (requestedFrom > 0 && 
+        (firstType === 'CORTEX_STEP_TYPE_CONVERSATION_HISTORY' || 
+         firstType === 'CORTEX_STEP_TYPE_USER_INPUT' ||
+         firstType === 'CONVERSATION_HISTORY' ||
+         firstType === 'USER_INPUT')) {
+        return 0;
+    }
+
+    return steps.length > expectedRange ? 0 : requestedFrom;
 }
 
 module.exports = { stepCache, ensureCached, getStepCountAndStatus, fetchAllSteps, detectApiStartIndex, fetchingSet };


### PR DESCRIPTION
### Description
This PR fixes an issue where the conversation history (especially long sessions) gets partially cut off and stops loading newer messages after a certain point.

### Cause of the Issue
The Antigravity Language Server (LS) JSON API (`GetCascadeTrajectorySteps`) has a known bug where it ignores the requested `startIndex` and always starts from `0`. It also caps the response length. 
To work around this, the Deck server checks the returned count against the expected count to detect if the response was sent from `0`. 

However, if a conversation is very long (e.g. 980+ steps) and the Deck requests the latest window of 500 steps starting from `fromIndex=487`, the LS JSON API returns its max capacity (e.g., 374 steps) starting from `0`. 
Since `jsonCount (374) < expectedCount (500)`, the current logic fails to detect that it started from `0`. It then incorrectly assumes it started from `fromIndex (487)` and fetches the rest via the binary API starting from `860`. This creates a gap where steps `374` to `859` are completely missing from the cache, making the conversation look cut off.

### Solution
1. **Accurate Start Index Detection**: Improved `detectApiStartIndex` to check the actual `stepIndex` or `step_index` in the first step's metadata, falling back to checking if the step is an initial step (like `CONVERSATION_HISTORY` or `USER_INPUT`) when the request starts from a index > 0.
2. **Proper Slicing & Buffering**: In `fetchAllSteps`, if the JSON response starts from `0` but covers the desired range, it slices the correct portion. If it doesn't cover the entire range, it extracts the overlapping part and fetches the remaining steps via the binary API without creating gaps.
3. Updated `poller.js` to pass the entire `freshSteps` array to `detectApiStartIndex` rather than just its length.